### PR TITLE
feat: extend demo with partial edits example

### DIFF
--- a/multiple-versions-concept/beefree-cookbook-email-sequence.md
+++ b/multiple-versions-concept/beefree-cookbook-email-sequence.md
@@ -1,30 +1,59 @@
-# Create AI-generated Email Sequences in Beefree SDK with Anthropic's Claude AI and Simple Schema
+---
+description: >-
+  Create AI-generated Email Sequences in Beefree SDK with Anthropic's Claude AI and
+  Simple Schema
+---
 
-This recipe demonstrates how to build an AI-powered email sequence creation system that generates three strategically designed emails using Anthropic's Claude API and converts them to full Beefree SDK templates using the Simple Schema format.
+# Create AI-generated Email Sequences in Beefree SDK with Claude AI
 
 ## Overview
 
+This recipe explains how to build an AI-powered email sequence creation system that generates three strategically designed emails using [Anthropic's Messages API](https://docs.anthropic.com/en/api/messages), along with the [Claude Sonnet 4 model](https://docs.anthropic.com/en/docs/about-claude/models/overview#model-names), and converts them to full Beefree SDK templates using both [Simple Schema](../../data-structures/simple-schema) and the [Content Services API](../../apis/content-services-api).
+
 This recipe covers:
-1. **Simple Schema**: Understanding the template structure and unified schema for multiple emails
-2. **Anthropic API Integration**: Structuring sequential API calls with different contexts
-3. **Frontend Integration**: Capturing user input and managing multiple email generation
-4. **Response Parsing**: Extracting and validating JSON from multiple AI responses
-5. **Beefree SDK Integration**: Converting multiple simple templates to full templates and managing navigation
+
+1. **Simple Schema**: Understanding the [template structure](../../data-structures/simple-schema/template-schema) and [unified schema](../../../data-structures/simple-schema#simple-unified-schema) for multiple emails.
+2. **Anthropic API Integration**: [Structuring sequential API calls](https://docs.anthropic.com/en/api/messages) with different contexts for each email type.
+3. **Frontend Integration**: Capturing end user email descriptions and managing progressive UI updates for multiple email generation.
+4. **Response Parsing**: Extracting and validating JSON from multiple AI responses with error correction loops.
+5. **Beefree SDK Integration**: Converting [multiple simple templates to full templates](../../../apis/content-services-api/convert#simple-to-full-json) and [managing navigation between emails](../../getting-started/readme/installation/methods-and-events).
+
+Reference the complete code for this project in the [multiple-versions-concept](broken-reference) folder inside the [Simple Schema GitHub repository](https://github.com/BeefreeSDK/beefree-sdk-simple-schema/tree/main).
+
+{% embed url="https://github.com/BeefreeSDK/beefree-sdk-simple-schema/tree/main/multiple-versions-concept" %}
 
 ## Prerequisites
 
-- Node.js (v14 or higher)
-- Anthropic API key
-- Beefree SDK credentials
-- Basic knowledge of JavaScript and Express.js
+* [Node.js](broken-reference)
+* [Anthropic API key](https://docs.anthropic.com/en/api/overview)
+* [Beefree SDK credentials](../../../getting-started/readme/create-an-application#obtain-your-client-id-and-client-secret)
+* Understanding of Beefree SDK's [Simple Schema](../../data-structures/simple-schema)
+* Knowledge of Beefree SDK's [Content Services API](../../apis/content-services-api) and [`/simple-to-full-json endpoint`](../../../apis/content-services-api/convert#simple-to-full-json)&#x20;
 
-## Core Concepts
+## Core Concepts and Steps
 
-### 1. Simple Schema Structure for Sequences
+This section details all of the core concepts required to integrate AI-generated email sequences within Beefree SDK. It includes descriptions of each concept, sample code, and the complete implementation at the end, along with customization tips.
 
-The Simple Schema remains the same for each email, but we generate three different emails with specific purposes:
+As a reminder, the complete code for this recipe is available for reference in [GitHub](broken-reference).
 
-#### Email Types and Contexts
+The following video shows the final result, and how the code for this recipe looks when you run it locally on your machine. &#x20;
+
+{% embed url="https://screen.studio/share/G7GQSZet" %}
+
+&#x20;The following diagram shows how these core concepts relate to one another to create the experience shown in the video above.
+
+<figure><img src="https://806400411-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2F8c7XIQHfAtM23Dp3ozIC%2Fuploads%2FUM25XtPneeIwKIlBMeol%2Fimage.png?alt=media&#x26;token=ba9b41e4-be22-4c18-b79c-7d98cf232ce4" alt=""><figcaption></figcaption></figure>
+
+## 1. Simple Schema Structure for Sequences
+
+[Simple Schema](../../data-structures/simple-schema) is a simplified JSON format that makes it easy to generate email templates programmatically. It uses a hierarchical structure with templates, rows, columns, and modules. Understanding and using Simple Schema is critical for building AI-powered workflows, because it's simpler JSON makes it much easier for AI to read, understand, and build. Beefree SDK's full JSON is complex and feature-rich, making it difficult to train AI on.&#x20;
+
+For email sequences, the Simple Schema remains the same for each email, but we generate three different emails with specific purposes and contexts.
+
+#### **Email Types and Contexts**
+
+The following code snippet shows how to define different email types with specific contexts for sequence generation.
+
 ```javascript
 const emailTypes = [
   { 
@@ -45,7 +74,10 @@ const emailTypes = [
 ];
 ```
 
-#### Template Structure (Same for all emails)
+#### **Template Structure (Same for all emails)**
+
+The following code snippet shows the template structure for simple JSON that applies to all emails in the sequence.
+
 ```json
 {
   "template": {
@@ -82,9 +114,28 @@ const emailTypes = [
 }
 ```
 
+#### **Supported Module Types**
+
+Simple Schema supports the following module types:
+
+* `title` - Email titles and headings
+* `paragraph` - Text content
+* `button` - Call-to-action buttons
+* `image` - Images and graphics
+* `divider` - Visual separators
+* `html` - Custom HTML content
+* `list` - Bulleted or numbered lists
+* `menu` - Menus
+* `icons` - Social media and other icons
+
 ### 2. Sequential Anthropic API Integration
 
-#### Sequential Email Creation Function
+This section discusses how to structure and make sequential API calls to Anthropic for generating multiple emails with different contexts.
+
+#### **Sequential Email Creation Function**
+
+The following code snippet shows how to create emails sequentially with different contexts for each email type.
+
 ```javascript
 async function createEmail(index, description) {
   if (index >= emailTypes.length) {
@@ -205,9 +256,37 @@ async function createEmail(index, description) {
 }
 ```
 
+#### **API Call Structure**
+
+The following code snippet shows an example API call to Anthropic for sequential email generation.
+
+```javascript
+const response = await fetch('https://api.anthropic.com/v1/messages', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'x-api-key': 'your-anthropic-api-key',
+    'anthropic-version': '2023-06-01'
+  },
+  body: JSON.stringify({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 8000,
+    messages: [{
+      role: 'user',
+      content: prompt
+    }]
+  })
+});
+```
+
 ### 3. Frontend Integration for Sequences
 
-#### Sequence Initialization
+This section discusses the Frontend integration and how to capture an end user's email description prompt, manage progressive UI updates, and handle navigation between multiple emails.
+
+#### **Sequence Initialization**
+
+The following code snippet shows how to initialize the email sequence creation process.
+
 ```javascript
 async function processEmailSequence(userDescription) {
   isProcessing = true;
@@ -220,7 +299,27 @@ async function processEmailSequence(userDescription) {
 }
 ```
 
-#### Progressive UI Updates
+#### **Capturing User Input**
+
+```javascript
+function sendMessage() {
+  if (isProcessing) return;
+  
+  const message = userInput.value.trim();
+  if (!message) return;
+
+  addMessage('user', message);
+  userInput.value = '';
+  userInput.style.height = 'auto';
+  
+  processEmailSequence(message);
+}
+```
+
+#### **Progressive UI Updates**
+
+The following code snippet shows how to update the UI progressively as each email is created.
+
 ```javascript
 function displayEmailButton(emailName, storageKey) {
   welcomeState.classList.add('hidden');
@@ -274,7 +373,12 @@ function displayAllEmailButtons() {
 
 ### 4. Response Parsing for Multiple Emails
 
-#### Sequential Parsing Logic
+This section includes two important topics. The first is how to parse the response from Anthropic to only get the simple JSON and pass it to the `/simple-to-full-json` endpoint. The second is how to configure a second API call in the event the first one fails. Beefree SDK provides comprehensive feedback in the error message for a failed `/simple-to-full-json` API call. By applying this comprehensive feedback in a second API, the AI model being used can typically return a valid simple JSON ready for conversion to full JSON.
+
+#### **Sequential Parsing Logic**
+
+The following code snippet shows how to parse responses for multiple emails in sequence.
+
 ```javascript
 // Extract the text content from the response
 let emailJsonText = '';
@@ -321,7 +425,8 @@ try {
 }
 ```
 
-#### Error Correction for Sequences
+#### **Error Correction for Sequences**
+
 ```javascript
 // If Beefree API returns validation errors, send back to Anthropic for correction
 if (!beefreeResponse.ok) {
@@ -371,7 +476,12 @@ const correctionResponse = await fetch('/api/anthropic', {
 
 ### 5. Beefree SDK Integration for Sequences
 
-#### Multiple Template Storage
+This section discusses the Beefree SDK integration for managing multiple emails. Beefree SDK provides the editing environment to load the full JSON into once it is created. Once it is loaded within the editor, the end user can begin customizing their AI-generated email design and navigate between different emails in the sequence.
+
+#### **Multiple Template Storage**
+
+The following code snippet shows how to store multiple emails with specific keys for navigation.
+
 ```javascript
 // Store each email with a specific key
 localStorage.setItem('welcomeEmailJson', JSON.stringify(welcomeFullJson));
@@ -379,7 +489,8 @@ localStorage.setItem('onboardingEmailJson', JSON.stringify(onboardingFullJson));
 localStorage.setItem('upgradeEmailJson', JSON.stringify(upgradeFullJson));
 ```
 
-#### Opening Specific Emails in Builder
+#### **Opening Specific Emails in Builder**
+
 ```javascript
 function openInBuilder(storageKey, emailName) {
   const emailJson = localStorage.getItem(storageKey);
@@ -394,7 +505,36 @@ function openInBuilder(storageKey, emailName) {
 }
 ```
 
-#### Persistent Email Navigation
+#### **Converting Simple to Full JSON**
+
+```javascript
+// Convert simple JSON to full JSON using Beefree CSAPI
+const beefreeResponse = await fetch('/api/beefree/simple-to-full', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    template: emailJson.template
+  })
+});
+
+if (!beefreeResponse.ok) {
+  const errorData = await beefreeResponse.text();
+  throw new Error(`Failed to convert template: ${beefreeResponse.status} ${beefreeResponse.statusText}`);
+}
+
+const fullJson = await beefreeResponse.json();
+console.log('Full JSON from Beefree:', fullJson);
+
+// Store the full JSON locally with specific key
+localStorage.setItem(emailType.key, JSON.stringify(fullJson));
+```
+
+#### **Persistent Email Navigation**
+
+The following code snippet shows how to manage navigation between emails and persist state.
+
 ```javascript
 // Check if we have existing emails when page loads
 function checkExistingEmails() {
@@ -452,7 +592,8 @@ function displayExistingEmails() {
 }
 ```
 
-#### Enhanced Builder with Navigation
+#### **Enhanced Builder with Navigation**
+
 ```javascript
 // In builder.html
 let selectedTemplate = null;
@@ -484,15 +625,82 @@ function returnToChat() {
   window.location.href = 'index.html';
 }
 
-// Add back button to HTML
-// <button class="back-button" onclick="returnToChat()">
-//   ← Return to Chat
-// </button>
+// Beefree SDK configuration
+const beeConfig = {
+  container: 'bee-plugin-container',
+  uid: 'demo-user-' + Date.now(),
+  language: 'en-US',
+  specialLinks: [
+    {
+      type: "unsubscribe",
+      label: "Unsubscribe",
+      link: "http://[unsubscribe]/",
+    },
+    {
+      type: "subscribe",
+      label: "Subscribe",
+      link: "http://[subscribe]/",
+    },
+  ],
+  mergeTags: [
+    {
+      name: "First Name",
+      value: "[first_name]",
+    },
+    {
+      name: "Last Name",
+      value: "[last_name]",
+    },
+    {
+      name: "Email",
+      value: "[email]",
+    },
+  ],
+  onSave: function (jsonFile, htmlFile) {
+    console.log("Template saved:", jsonFile);
+  },
+  onAutoSave: function (jsonFile) {
+    console.log("Auto-saving template...");
+    localStorage.setItem("email.autosave", jsonFile);
+  },
+  onSend: function (htmlFile) {
+    console.log("Email ready to send:", htmlFile);
+  },
+  onError: function (errorMessage) {
+    console.error("Beefree SDK error:", errorMessage);
+  }
+};
+
+// Initialize Beefree SDK
+function initializeBeefree(authResponse) {
+  BeePlugin.create(authResponse, beeConfig, function (beePluginInstance) {
+    console.log('Beefree SDK initialized successfully');
+    
+    // Check if we have a template to load
+    if (selectedTemplate) {
+      try {
+        beePluginInstance.start(selectedTemplate);
+        console.log('Loaded template from localStorage');
+      } catch (error) {
+        console.error('Error loading template:', error);
+        // Fallback to empty template
+        beePluginInstance.start();
+      }
+    } else {
+      // Start with empty template
+      beePluginInstance.start();
+      console.log('Started with empty template');
+    }
+  });
+}
 ```
 
 ## Complete Implementation
 
-### Proxy Server (proxy-server.js)
+This section includes the code for both APIs together (Anthropic API call and `/simple-to-full-json` API call), and the dependencies they require.&#x20;
+
+#### Proxy Server (proxy-server.js)
+
 ```javascript
 const express = require('express');
 const cors = require('cors');
@@ -662,18 +870,22 @@ app.listen(PORT, () => {
 
 ## Customization Tips
 
-1. **Email Types**: Modify the `emailTypes` array to create different sequences (e.g., product launch, seasonal campaigns)
-2. **Context Customization**: Adjust the context prompts for each email type based on your specific needs
-3. **Sequential Logic**: Add delays between email generation or implement parallel processing
-4. **Progress Tracking**: Add more detailed progress indicators for each email
-5. **Template Validation**: Implement sequence-specific validation rules
-6. **User Experience**: Add preview functionality for the entire sequence
+This section list a few customization tips you can apply to the code in your own environment.&#x20;
+
+* **Email Types**: Modify the `emailTypes` array to create different sequences (e.g., product launch, seasonal campaigns)
+* **Context Customization**: Adjust the context prompts for each email type based on your specific needs
+* **Sequential Logic**: Add delays between email generation or implement parallel processing
+* **Progress Tracking**: Add more detailed progress indicators for each email
+* **Template Validation**: Implement sequence-specific validation rules
+* **User Experience**: Add preview functionality for the entire sequence
 
 ## Troubleshooting
 
-- **Sequential Errors**: Handle failures in individual email generation without stopping the entire sequence
-- **Storage Management**: Implement cleanup for old sequences and manage localStorage limits
-- **Navigation Issues**: Ensure proper state management when switching between emails
-- **Performance**: Optimize for multiple API calls and large template storage
+If you encounter any errors, try troubleshooting the following:
 
-This recipe provides a complete foundation for building AI-powered email sequence creation systems with Beefree SDK and Anthropic's Claude API. 
+* **Sequential Errors**: Handle failures in individual email generation without stopping the entire sequence
+* **Storage Management**: Implement cleanup for old sequences and manage localStorage limits
+* **Navigation Issues**: Ensure proper state management when switching between emails
+* **Performance**: Optimize for multiple API calls and large template storage
+
+This recipe provides a complete foundation for building AI-powered email sequence creation systems with Beefree SDK and Anthropic's Messages API and Claude Sonnet 4 model. 

--- a/partial-design-edits-concept/README.md
+++ b/partial-design-edits-concept/README.md
@@ -1,0 +1,126 @@
+# Partial Design Edits Concept
+
+This concept demonstrates how to integrate AI-powered partial design editing with the Beefree SDK. Users can upload existing templates and use natural language to make specific edits to their email designs.
+
+## Features
+
+- **Combined Interface**: Chat interface (1/3 screen) and Beefree SDK editor (2/3 screen) on the same page
+- **Template Upload**: Upload existing JSON templates via the "Upload Template" button
+- **AI-Powered Edits**: Use natural language to describe specific changes to your design
+- **Real-time Tracking**: onChange and onSave callbacks enabled for tracking design changes
+- **Local Storage**: Templates are stored locally for persistence
+- **Full-to-Simple Conversion**: Automatically converts full JSON to simple JSON for AI processing
+- **Simple-to-Full Conversion**: Converts AI-generated simple JSON back to full JSON for the editor
+
+## How It Works
+
+1. **Upload Template**: Click "Upload Template" to load an existing JSON template
+2. **Save Design**: Click the Save button in the Beefree editor to enable chat functionality
+3. **Chat with AI**: Describe specific changes you want to make to your design
+4. **AI Processing**: The system converts your template to simple JSON, sends it to AI with your request, and converts the result back to full JSON
+5. **View Changes**: The updated design is automatically loaded into the editor
+
+## Example Chat Prompts
+
+- "Rewrite the paragraph in row 3 column 2"
+- "Add another row promoting our latest blog posts at the end of the design"
+- "Change the color of the main heading to blue"
+- "Add a button after the first paragraph"
+- "Replace the image in the header with a new logo"
+
+## Technical Implementation
+
+### API Endpoints
+
+- `/api/anthropic` - Sends edit requests to Claude AI
+- `/api/beefree/auth` - Authenticates with Beefree SDK
+- `/api/beefree/simple-to-full` - Converts simple JSON to full JSON
+- `/api/beefree/full-to-simple` - Converts full JSON to simple JSON
+
+### Beefree SDK Configuration
+
+The SDK is configured with:
+- `trackChanges: true` - Enables onChange tracking
+- `onSave` callback - Stores template and enables chat
+- `onChange` callback - Logs changes to console and updates local storage
+
+### Local Storage
+
+- `currentTemplate` - Stores the current template JSON
+- `email.autosave` - Stores autosaved versions
+
+## Setup
+
+1. Copy `credentials.example.js` to `credentials.js`
+2. Add your API keys:
+   ```javascript
+   module.exports = {
+     anthropic_api_key: 'your_anthropic_key_here',
+     beefree_api_key: 'your_beefree_key_here'
+   };
+   ```
+
+3. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+4. Start the server:
+   ```bash
+   npm start
+   ```
+
+5. Open `http://localhost:3000` in your browser
+
+## Testing
+
+You can test the functionality by uploading the included `example-template.json` file:
+
+1. Click "Upload Template" in the header
+2. Select `example-template.json` from the file picker
+3. Click "Save" in the Beefree editor
+4. Try chat prompts like:
+   - "Change the main heading to 'Welcome to Our New Platform'"
+   - "Add a new row with a promotional offer"
+   - "Change the button color to red"
+
+## File Structure
+
+```
+partial-design-edits-concept/
+├── index.html              # Main interface with chat and editor
+├── proxy-server.js         # Backend API proxy
+├── credentials.js          # API keys (create from example)
+├── example-template.json   # Example template for testing
+├── package.json            # Dependencies
+└── README.md              # This file
+```
+
+## Usage Flow
+
+1. **Initial State**: Chat shows "First save your design. Then, start chatting here to apply edits to parts of your design."
+2. **Upload Template**: Click upload button and select a JSON file
+3. **Save Design**: Click Save in the editor to enable chat
+4. **Chat Enabled**: Placeholder text updates with example prompts
+5. **Make Edits**: Type natural language descriptions of changes
+6. **AI Processing**: Shows "AI is working on applying your edits to your design"
+7. **View Results**: Updated design loads automatically in the editor
+
+## Console Logging
+
+The `onChange` callback logs all JSON changes to the browser console for debugging and tracking purposes.
+
+## Error Handling
+
+- Invalid JSON files show error messages in chat
+- API errors are displayed to the user
+- Network issues are handled gracefully
+- Template validation ensures proper structure
+
+## Future Enhancements
+
+- Support for multiple template formats
+- Batch edit processing
+- Version history and rollback
+- Collaborative editing features
+- Advanced AI prompts for complex design changes 

--- a/partial-design-edits-concept/beefree-cookbook-partial-design-edits.md
+++ b/partial-design-edits-concept/beefree-cookbook-partial-design-edits.md
@@ -1,0 +1,853 @@
+---
+description: >-
+  Create AI-powered Partial Design Edits in Beefree SDK with Anthropic's Claude AI and
+  Simple Schema
+---
+
+# Create AI-powered Partial Design Edits in Beefree SDK with Claude AI
+
+## Overview
+
+This recipe explains how to build an AI-powered partial design editing system that makes targeted modifications to existing email templates using [Anthropic's Messages API](https://docs.anthropic.com/en/api/messages), along with the [Claude Sonnet 4 model](https://docs.anthropic.com/en/docs/about-claude/models/overview#model-names), and integrates with Beefree SDK using both [Simple Schema](../../data-structures/simple-schema) and the [Content Services API](../../apis/content-services-api).
+
+This recipe covers:
+
+1. **Simple Schema**: Understanding the [template structure](../../data-structures/simple-schema/template-schema) and [unified schema](../../../data-structures/simple-schema#simple-unified-schema) for partial edits.
+2. **Anthropic API Integration**: [Structuring API calls](https://docs.anthropic.com/en/api/messages) for targeted template modifications.
+3. **Frontend Integration**: Capturing end user edit requests and managing template state.
+4. **Response Parsing**: Extracting and validating partial JSON edits from AI responses.
+5. **Beefree SDK Integration**: Applying [partial edits to existing templates](../../../apis/content-services-api/convert#simple-to-full-json) and [updating the builder](../../getting-started/readme/installation/methods-and-events).
+
+Reference the complete code for this project in the [partial-design-edits-concept](broken-reference) folder inside the [Simple Schema GitHub repository](https://github.com/BeefreeSDK/beefree-sdk-simple-schema/tree/main).
+
+{% embed url="https://github.com/BeefreeSDK/beefree-sdk-simple-schema/tree/main/partial-design-edits-concept" %}
+
+## Prerequisites
+
+* [Node.js](broken-reference)
+* [Anthropic API key](https://docs.anthropic.com/en/api/overview)
+* [Beefree SDK credentials](../../../getting-started/readme/create-an-application#obtain-your-client-id-and-client-secret)
+* Understanding of Beefree SDK's [Simple Schema](../../data-structures/simple-schema)
+* Knowledge of Beefree SDK's [Content Services API](../../apis/content-services-api) and [`/simple-to-full-json endpoint`](../../../apis/content-services-api/convert#simple-to-full-json)&#x20;
+
+## Core Concepts and Steps
+
+This section details all of the core concepts required to integrate AI-powered partial design editing within Beefree SDK. It includes descriptions of each concept, sample code, and the complete implementation at the end, along with customization tips.
+
+As a reminder, the complete code for this recipe is available for reference in [GitHub](broken-reference).
+
+The following video shows the final result, and how the code for this recipe looks when you run it locally on your machine. &#x20;
+
+{% embed url="https://screen.studio/share/G7GQSZet" %}
+
+&#x20;The following diagram shows how these core concepts relate to one another to create the experience shown in the video above.
+
+<figure><img src="https://806400411-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2F8c7XIQHfAtM23Dp3ozIC%2Fuploads%2FUM25XtPneeIwKIlBMeol%2Fimage.png?alt=media&#x26;token=ba9b41e4-be22-4c18-b79c-7d98cf232ce4" alt=""><figcaption></figcaption></figure>
+
+## 1. Simple Schema Structure for Partial Edits
+
+[Simple Schema](../../data-structures/simple-schema) is a simplified JSON format that makes it easy to generate email templates programmatically. It uses a hierarchical structure with templates, rows, columns, and modules. Understanding and using Simple Schema is critical for building AI-powered workflows, because it's simpler JSON makes it much easier for AI to read, understand, and build. Beefree SDK's full JSON is complex and feature-rich, making it difficult to train AI on.&#x20;
+
+For partial design edits, we work with existing templates and make targeted modifications to specific sections while preserving the overall structure.
+
+#### **Template Structure for Edits**
+
+The following code snippet shows the template structure for simple JSON that supports partial edits.
+
+```json
+{
+  "template": {
+    "type": "email",
+    "rows": [
+      {
+        "name": "Row Name",
+        "columns": [
+          {
+            "weight": 12,
+            "modules": [
+              {
+                "type": "title",
+                "text": "Your title here"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "settings": {
+      "linkColor": "#0066CC",
+      "background-color": "#ffffff",
+      "contentAreaBackgroundColor": "#ffffff",
+      "width": 600
+    },
+    "metadata": {
+      "title": "Email Template",
+      "description": "Generated email template",
+      "subject": "Your Email Subject",
+      "preheader": "Email preheader text"
+    }
+  }
+}
+```
+
+#### **Supported Module Types for Edits**
+
+Simple Schema supports the following module types for partial edits:
+
+* `title` - Email titles and headings
+* `paragraph` - Text content
+* `button` - Call-to-action buttons
+* `image` - Images and graphics
+* `divider` - Visual separators
+* `html` - Custom HTML content
+* `list` - Bulleted or numbered lists
+* `menu` - Menus
+* `icons` - Social media and other icons
+
+#### **Edit Types and Contexts**
+
+The following code snippet shows how to define different types of edits with specific contexts.
+
+```javascript
+const editTypes = [
+  { 
+    name: 'Content Update', 
+    key: 'contentEdit', 
+    context: 'update the content while maintaining the existing design and structure' 
+  },
+  { 
+    name: 'Style Modification', 
+    key: 'styleEdit', 
+    context: 'modify colors, fonts, and styling while keeping the content intact' 
+  },
+  { 
+    name: 'Layout Adjustment', 
+    key: 'layoutEdit', 
+    context: 'adjust the layout and spacing while preserving the content and overall design' 
+  },
+  { 
+    name: 'Module Addition', 
+    key: 'moduleEdit', 
+    context: 'add new modules or sections while maintaining the existing design consistency' 
+  }
+];
+```
+
+### 2. Anthropic API Integration for Partial Edits
+
+This section discusses how to structure and make API calls to Anthropic for generating targeted template modifications.
+
+#### **API Call Structure**
+
+The following code snippet shows an example API call to Anthropic for partial design edits.
+
+```javascript
+const response = await fetch('https://api.anthropic.com/v1/messages', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'x-api-key': 'your-anthropic-api-key',
+    'anthropic-version': '2023-06-01'
+  },
+  body: JSON.stringify({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 8000,
+    messages: [{
+      role: 'user',
+      content: prompt
+    }]
+  })
+});
+```
+
+#### **Partial Edit Request**
+
+The following code snippet shows an example prompt for partial design edits.
+
+```javascript
+const prompt = `I have an existing email template that I want to modify. Here is the current template structure: ${JSON.stringify(currentTemplate, null, 2)}. 
+
+The user wants to make the following changes: "${userEditRequest}". 
+
+Please provide ONLY the modified sections of the template that need to be changed. Return the changes in this format:
+
+{
+  "edits": [
+    {
+      "type": "update",
+      "path": "template.rows[0].columns[0].modules[0]",
+      "content": {
+        "type": "title",
+        "text": "Updated title text"
+      }
+    },
+    {
+      "type": "add",
+      "path": "template.rows[1]",
+      "content": {
+        "name": "New Row",
+        "columns": [
+          {
+            "weight": 12,
+            "modules": [
+              {
+                "type": "paragraph",
+                "text": "New content here"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+
+Available edit types:
+- "update": Modify existing content
+- "add": Add new sections or modules
+- "remove": Remove existing sections or modules
+- "replace": Replace entire sections
+
+Available module types: title, paragraph, button, image, divider, html, list, menu, icons
+
+Make sure the edits maintain the overall design consistency and follow email marketing best practices.`;
+```
+
+#### **Sample Response**
+
+The following code snippet shows an example response from Anthropic for partial edits.
+
+```json
+{
+  "id": "msg_01MVjrNK8LRDxEEFdWuHRdED",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-4-20250514",
+  "content": [
+    {
+      "type": "text",
+      "text": "```json\n{\n  \"edits\": [\n    {\n      \"type\": \"update\",\n      \"path\": \"template.rows[0].columns[0].modules[0]\",\n      \"content\": {\n        \"type\": \"title\",\n        \"text\": \"Updated Welcome Message!\"\n      }\n    },\n    {\n      \"type\": \"add\",\n      \"path\": \"template.rows[1]\",\n      \"content\": {\n        \"name\": \"New Section\",\n        \"columns\": [\n          {\n            \"weight\": 12,\n            \"modules\": [\n              {\n                \"type\": \"paragraph\",\n                \"text\": \"This is new content added to your email.\"\n              }\n            ]\n          }\n        ]\n      }\n    }\n  ]\n}\n```"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "usage": {
+    "input_tokens": 727,
+    "output_tokens": 1809
+  }
+}
+```
+
+### 3. Frontend Integration for Partial Edits
+
+This section discusses the Frontend integration and how to capture an end user's edit requests, manage template state, and provide real-time preview of changes.
+
+#### **Capturing Edit Requests**
+
+The following code snippet shows how to capture user edit requests.
+
+```javascript
+function sendEditRequest() {
+  if (isProcessing) return;
+  
+  const editRequest = userInput.value.trim();
+  if (!editRequest) return;
+
+  addMessage('user', editRequest);
+  userInput.value = '';
+  userInput.style.height = 'auto';
+  
+  processEditRequest(editRequest);
+}
+```
+
+#### **Processing Edit Requests**
+
+```javascript
+async function processEditRequest(userEditRequest) {
+  isProcessing = true;
+  sendButton.disabled = true;
+  showTypingIndicator();
+
+  try {
+    // Get the current template from localStorage or state
+    const currentTemplate = getCurrentTemplate();
+    
+    if (!currentTemplate) {
+      throw new Error('No template found. Please load a template first.');
+    }
+
+    // Create the prompt for Anthropic
+    const prompt = `I have an existing email template that I want to modify. Here is the current template structure: ${JSON.stringify(currentTemplate, null, 2)}. 
+
+    The user wants to make the following changes: "${userEditRequest}". 
+
+    Please provide ONLY the modified sections of the template that need to be changed. Return the changes in this format:
+
+    {
+      "edits": [
+        {
+          "type": "update",
+          "path": "template.rows[0].columns[0].modules[0]",
+          "content": {
+            "type": "title",
+            "text": "Updated title text"
+          }
+        }
+      ]
+    }
+
+    Available edit types:
+    - "update": Modify existing content
+    - "add": Add new sections or modules
+    - "remove": Remove existing sections or modules
+    - "replace": Replace entire sections
+
+    Available module types: title, paragraph, button, image, divider, html, list, menu, icons
+
+    Make sure the edits maintain the overall design consistency and follow email marketing best practices.`;
+
+    // Call Anthropic API
+    const response = await fetch('/api/anthropic', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        prompt: prompt
+      })
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      throw new Error(`Failed to process edit: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    console.log('Anthropic API response:', data);
+    
+    // Continue with parsing and applying edits...
+  } catch (error) {
+    console.error('Error processing edit:', error);
+    addMessage('assistant', `Sorry, there was an error processing your edit: ${error.message}`);
+  } finally {
+    isProcessing = false;
+    sendButton.disabled = false;
+  }
+}
+```
+
+#### **Template State Management**
+
+```javascript
+function getCurrentTemplate() {
+  const templateData = localStorage.getItem('currentTemplate');
+  if (templateData) {
+    return JSON.parse(templateData);
+  }
+  return null;
+}
+
+function updateCurrentTemplate(template) {
+  localStorage.setItem('currentTemplate', JSON.stringify(template));
+  updatePreview(template);
+}
+
+function updatePreview(template) {
+  // Update the preview area with the modified template
+  const previewContainer = document.getElementById('template-preview');
+  if (previewContainer) {
+    // Generate HTML preview or show template structure
+    previewContainer.innerHTML = `<pre>${JSON.stringify(template, null, 2)}</pre>`;
+  }
+}
+```
+
+### 4. Response Parsing for Partial Edits
+
+This section includes two important topics. The first is how to parse the response from Anthropic to extract the edit instructions. The second is how to apply these edits to the existing template structure.
+
+#### **Extracting Edit Instructions**
+
+The following code snippet shows how to parse edit instructions from Anthropic's response.
+
+```javascript
+// Extract the text content from the response
+let editJsonText = '';
+if (data.content && data.content.length > 0) {
+  const textBlock = data.content.find(block => block.type === 'text');
+  if (textBlock) {
+    editJsonText = textBlock.text;
+  } else {
+    throw new Error('No text content found in API response');
+  }
+} else {
+  throw new Error('Invalid response structure from Anthropic API');
+}
+
+// Parse the JSON from the response
+let editInstructions;
+try {
+  // First try to find JSON in code blocks
+  const jsonMatch = editJsonText.match(/```json\s*([\s\S]*?)\s*```/) || 
+                   editJsonText.match(/```\s*([\s\S]*?)\s*```/);
+  
+  if (jsonMatch) {
+    editInstructions = JSON.parse(jsonMatch[1]);
+  } else {
+    // If no code blocks, try to find JSON object in the text
+    const jsonObjectMatch = editJsonText.match(/\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}/);
+    if (jsonObjectMatch) {
+      editInstructions = JSON.parse(jsonObjectMatch[0]);
+    } else {
+      throw new Error('No JSON found in response');
+    }
+  }
+  
+  // Validate that we have the required edit structure
+  if (!editInstructions.edits || !Array.isArray(editInstructions.edits)) {
+    throw new Error('Invalid edit structure - missing edits array');
+  }
+  
+  console.log('Parsed edit instructions:', editInstructions);
+} catch (parseError) {
+  console.error('JSON parsing error:', parseError);
+  console.error('Raw response text:', editJsonText);
+  throw new Error(`Invalid JSON format in response: ${parseError.message}`);
+}
+```
+
+#### **Applying Edits to Template**
+
+```javascript
+function applyEditsToTemplate(template, edits) {
+  const updatedTemplate = JSON.parse(JSON.stringify(template)); // Deep clone
+  
+  edits.forEach(edit => {
+    try {
+      switch (edit.type) {
+        case 'update':
+          updateTemplatePath(updatedTemplate, edit.path, edit.content);
+          break;
+        case 'add':
+          addToTemplatePath(updatedTemplate, edit.path, edit.content);
+          break;
+        case 'remove':
+          removeFromTemplatePath(updatedTemplate, edit.path);
+          break;
+        case 'replace':
+          replaceTemplatePath(updatedTemplate, edit.path, edit.content);
+          break;
+        default:
+          console.warn(`Unknown edit type: ${edit.type}`);
+      }
+    } catch (error) {
+      console.error(`Error applying edit: ${error.message}`, edit);
+    }
+  });
+  
+  return updatedTemplate;
+}
+
+function updateTemplatePath(template, path, content) {
+  const pathParts = path.split('.');
+  let current = template;
+  
+  for (let i = 0; i < pathParts.length - 1; i++) {
+    const part = pathParts[i];
+    if (part.includes('[')) {
+      // Handle array access
+      const arrayMatch = part.match(/(\w+)\[(\d+)\]/);
+      if (arrayMatch) {
+        const [, arrayName, index] = arrayMatch;
+        current = current[arrayName][parseInt(index)];
+      }
+    } else {
+      current = current[part];
+    }
+  }
+  
+  const lastPart = pathParts[pathParts.length - 1];
+  if (lastPart.includes('[')) {
+    const arrayMatch = lastPart.match(/(\w+)\[(\d+)\]/);
+    if (arrayMatch) {
+      const [, arrayName, index] = arrayMatch;
+      current[arrayName][parseInt(index)] = content;
+    }
+  } else {
+    current[lastPart] = content;
+  }
+}
+
+function addToTemplatePath(template, path, content) {
+  const pathParts = path.split('.');
+  let current = template;
+  
+  for (let i = 0; i < pathParts.length - 1; i++) {
+    const part = pathParts[i];
+    if (part.includes('[')) {
+      const arrayMatch = part.match(/(\w+)\[(\d+)\]/);
+      if (arrayMatch) {
+        const [, arrayName, index] = arrayMatch;
+        current = current[arrayName][parseInt(index)];
+      }
+    } else {
+      current = current[part];
+    }
+  }
+  
+  const lastPart = pathParts[pathParts.length - 1];
+  if (lastPart.includes('[')) {
+    const arrayMatch = lastPart.match(/(\w+)\[(\d+)\]/);
+    if (arrayMatch) {
+      const [, arrayName, index] = arrayMatch;
+      current[arrayName].splice(parseInt(index), 0, content);
+    }
+  } else {
+    if (Array.isArray(current[lastPart])) {
+      current[lastPart].push(content);
+    } else {
+      current[lastPart] = content;
+    }
+  }
+}
+```
+
+### 5. Beefree SDK Integration for Partial Edits
+
+This section discusses the Beefree SDK integration for applying partial edits. Beefree SDK provides the editing environment to load the modified JSON into once the edits are applied. Once it is loaded within the editor, the end user can see the changes and continue customizing their email design.
+
+#### **Converting Modified Template to Full JSON**
+
+```javascript
+// Convert modified simple JSON to full JSON using Beefree CSAPI
+const beefreeResponse = await fetch('/api/beefree/simple-to-full', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    template: modifiedTemplate.template
+  })
+});
+
+if (!beefreeResponse.ok) {
+  const errorData = await beefreeResponse.text();
+  throw new Error(`Failed to convert modified template: ${beefreeResponse.status} ${beefreeResponse.statusText}`);
+}
+
+const fullJson = await beefreeResponse.json();
+console.log('Full JSON from Beefree:', fullJson);
+
+// Store the modified full JSON locally
+localStorage.setItem('modifiedEmailJson', JSON.stringify(fullJson));
+```
+
+#### **Loading Modified Template in Builder**
+
+```javascript
+// In builder.html
+let selectedTemplate = null;
+try {
+  const emailData = localStorage.getItem('modifiedEmailJson');
+  if (emailData) {
+    selectedTemplate = JSON.parse(emailData);
+    console.log('Loaded modified email data from storage:', selectedTemplate);
+    
+    // Clear the stored data after loading
+    localStorage.removeItem('modifiedEmailJson');
+  }
+} catch (e) {
+  console.error('Error parsing email data:', e);
+}
+
+// Beefree SDK configuration
+const beeConfig = {
+  container: 'bee-plugin-container',
+  uid: 'demo-user-' + Date.now(),
+  language: 'en-US',
+  specialLinks: [
+    {
+      type: "unsubscribe",
+      label: "Unsubscribe",
+      link: "http://[unsubscribe]/",
+    },
+    {
+      type: "subscribe",
+      label: "Subscribe",
+      link: "http://[subscribe]/",
+    },
+  ],
+  mergeTags: [
+    {
+      name: "First Name",
+      value: "[first_name]",
+    },
+    {
+      name: "Last Name",
+      value: "[last_name]",
+    },
+    {
+      name: "Email",
+      value: "[email]",
+    },
+  ],
+  onSave: function (jsonFile, htmlFile) {
+    console.log("Template saved:", jsonFile);
+  },
+  onAutoSave: function (jsonFile) {
+    console.log("Auto-saving template...");
+    localStorage.setItem("email.autosave", jsonFile);
+  },
+  onSend: function (htmlFile) {
+    console.log("Email ready to send:", htmlFile);
+  },
+  onError: function (errorMessage) {
+    console.error("Beefree SDK error:", errorMessage);
+  }
+};
+
+// Initialize Beefree SDK
+function initializeBeefree(authResponse) {
+  BeePlugin.create(authResponse, beeConfig, function (beePluginInstance) {
+    console.log('Beefree SDK initialized successfully');
+    
+    // Check if we have a modified template to load
+    if (selectedTemplate) {
+      try {
+        beePluginInstance.start(selectedTemplate);
+        console.log('Loaded modified template from localStorage');
+      } catch (error) {
+        console.error('Error loading modified template:', error);
+        // Fallback to empty template
+        beePluginInstance.start();
+      }
+    } else {
+      // Start with empty template
+      beePluginInstance.start();
+      console.log('Started with empty template');
+    }
+  });
+}
+```
+
+#### **Edit History and Undo Functionality**
+
+```javascript
+// Track edit history for undo functionality
+let editHistory = [];
+let currentHistoryIndex = -1;
+
+function saveEditState(template) {
+  // Remove any future history if we're not at the end
+  editHistory = editHistory.slice(0, currentHistoryIndex + 1);
+  
+  // Add new state
+  editHistory.push(JSON.parse(JSON.stringify(template)));
+  currentHistoryIndex++;
+  
+  // Limit history size
+  if (editHistory.length > 10) {
+    editHistory.shift();
+    currentHistoryIndex--;
+  }
+  
+  updateUndoButtons();
+}
+
+function undoEdit() {
+  if (currentHistoryIndex > 0) {
+    currentHistoryIndex--;
+    const previousTemplate = editHistory[currentHistoryIndex];
+    updateCurrentTemplate(previousTemplate);
+    updateUndoButtons();
+  }
+}
+
+function redoEdit() {
+  if (currentHistoryIndex < editHistory.length - 1) {
+    currentHistoryIndex++;
+    const nextTemplate = editHistory[currentHistoryIndex];
+    updateCurrentTemplate(nextTemplate);
+    updateUndoButtons();
+  }
+}
+
+function updateUndoButtons() {
+  const undoButton = document.getElementById('undo-button');
+  const redoButton = document.getElementById('redo-button');
+  
+  if (undoButton) {
+    undoButton.disabled = currentHistoryIndex <= 0;
+  }
+  
+  if (redoButton) {
+    redoButton.disabled = currentHistoryIndex >= editHistory.length - 1;
+  }
+}
+```
+
+## Complete Implementation
+
+This section includes the code for both APIs together (Anthropic API call and `/simple-to-full-json` API call), and the dependencies they require.&#x20;
+
+#### Proxy Server (proxy-server.js)
+
+```javascript
+const express = require('express');
+const cors = require('cors');
+const fetch = require('node-fetch');
+const path = require('path');
+
+const app = express();
+const PORT = 3000;
+
+// Middleware
+app.use(cors());
+app.use(express.json());
+app.use(express.static(path.join(__dirname)));
+
+// Load credentials
+const credentials = require('./credentials.js');
+
+// Proxy endpoint for Anthropic API
+app.post('/api/anthropic', async (req, res) => {
+  try {
+    const { prompt } = req.body;
+    
+    if (!prompt) {
+      return res.status(400).json({ error: 'Prompt is required' });
+    }
+
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': credentials.anthropic_api_key,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 8000,
+        messages: [{
+          role: 'user',
+          content: prompt
+        }]
+      })
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      return res.status(response.status).json({ 
+        error: `Anthropic API error: ${response.status} ${response.statusText}`,
+        details: errorData
+      });
+    }
+
+    const data = await response.json();
+    res.json(data);
+    
+  } catch (error) {
+    console.error('Proxy server error:', error);
+    res.status(500).json({ error: 'Internal server error', details: error.message });
+  }
+});
+
+// Proxy endpoint for Beefree CSAPI - Simple to Full JSON
+app.post('/api/beefree/simple-to-full', async (req, res) => {
+  try {
+    const { template } = req.body;
+    
+    if (!template) {
+      return res.status(400).json({ error: 'Template is required' });
+    }
+
+    const response = await fetch('https://api.getbee.io/v1/conversion/simple-to-full-json', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${credentials.beefree_api_key}`
+      },
+      body: JSON.stringify({ template })
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      return res.status(response.status).json({ 
+        error: `Beefree API error: ${response.status} ${response.statusText}`,
+        details: errorData
+      });
+    }
+
+    const data = await response.json();
+    res.json(data);
+    
+  } catch (error) {
+    console.error('Proxy server error:', error);
+    res.status(500).json({ error: 'Internal server error', details: error.message });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Proxy server running on http://localhost:${PORT}`);
+});
+```
+
+## Partial Edit Strategies
+
+### Content Updates
+- **Purpose**: Modify text content while preserving design
+- **Context**: Update the content while maintaining the existing design and structure
+- **Key Elements**: 
+  - Text modifications
+  - Content replacement
+  - Message updates
+  - Call-to-action changes
+
+### Style Modifications
+- **Purpose**: Change colors, fonts, and styling
+- **Context**: Modify colors, fonts, and styling while keeping the content intact
+- **Key Elements**:
+  - Color scheme updates
+  - Font changes
+  - Spacing adjustments
+  - Visual enhancements
+
+### Layout Adjustments
+- **Purpose**: Modify structure and arrangement
+- **Context**: Adjust the layout and spacing while preserving the content and overall design
+- **Key Elements**:
+  - Column adjustments
+  - Row modifications
+  - Spacing changes
+  - Structure updates
+
+### Module Additions
+- **Purpose**: Add new content sections
+- **Context**: Add new modules or sections while maintaining the existing design consistency
+- **Key Elements**:
+  - New sections
+  - Additional modules
+  - Content blocks
+  - Interactive elements
+
+## Customization Tips
+
+This section list a few customization tips you can apply to the code in your own environment.&#x20;
+
+* **Edit Types**: Modify the `editTypes` array to support different types of modifications
+* **Validation Rules**: Add custom validation for specific edit types
+* **Preview Functionality**: Implement real-time preview of changes before applying
+* **Batch Edits**: Support multiple edits in a single request
+* **Template Versioning**: Implement version control for template modifications
+* **User Experience**: Add confirmation dialogs and progress indicators
+
+## Troubleshooting
+
+If you encounter any errors, try troubleshooting the following:
+
+* **Path Resolution**: Ensure edit paths correctly reference template structure
+* **Validation Errors**: Check that modifications maintain schema compliance
+* **State Management**: Verify template state is properly maintained across edits
+* **Performance**: Optimize for large templates and complex modifications
+
+This recipe provides a complete foundation for building AI-powered partial design editing systems with Beefree SDK and Anthropic's Messages API and Claude Sonnet 4 model.

--- a/partial-design-edits-concept/example-template.json
+++ b/partial-design-edits-concept/example-template.json
@@ -1,0 +1,144 @@
+{
+  "template": {
+    "type": "email",
+    "rows": [
+      {
+        "name": "header_row",
+        "columns": [
+          {
+            "weight": 12,
+            "modules": [
+              {
+                "type": "title",
+                "text": "Welcome to Our Newsletter",
+                "title": "h1",
+                "size": 24,
+                "line-height": 1,
+                "bold": true,
+                "align": "center",
+                "color": "#1A5276",
+                "padding-top": 20,
+                "padding-bottom": 10
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "intro_row",
+        "columns": [
+          {
+            "weight": 12,
+            "modules": [
+              {
+                "type": "paragraph",
+                "text": "Thank you for subscribing to our newsletter! We're excited to share the latest updates, tips, and insights with you.",
+                "align": "center",
+                "color": "#333333",
+                "size": 16
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "content_row",
+        "columns": [
+          {
+            "weight": 6,
+            "modules": [
+              {
+                "type": "title",
+                "text": "Latest News",
+                "title": "h2",
+                "size": 20,
+                "bold": true,
+                "color": "#2980B9",
+                "padding-bottom": 10
+              },
+              {
+                "type": "paragraph",
+                "text": "Stay up to date with our latest product releases and company announcements.",
+                "color": "#555555",
+                "size": 14
+              }
+            ]
+          },
+          {
+            "weight": 6,
+            "modules": [
+              {
+                "type": "title",
+                "text": "Tips & Tricks",
+                "title": "h2",
+                "size": 20,
+                "bold": true,
+                "color": "#2980B9",
+                "padding-bottom": 10
+              },
+              {
+                "type": "paragraph",
+                "text": "Discover helpful tips and best practices to make the most of our products.",
+                "color": "#555555",
+                "size": 14
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "cta_row",
+        "columns": [
+          {
+            "weight": 12,
+            "modules": [
+              {
+                "type": "button",
+                "text": "Read More",
+                "href": "https://example.com",
+                "color": "#FFFFFF",
+                "background-color": "#3498DB"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "footer_row",
+        "columns": [
+          {
+            "weight": 12,
+            "modules": [
+              {
+                "type": "divider",
+                "color": "#DDDDDD",
+                "height": 1,
+                "width": 80
+              },
+              {
+                "type": "paragraph",
+                "text": "© 2025 Example Company. All rights reserved.",
+                "align": "center",
+                "color": "#7F8C8D",
+                "size": 12
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "settings": {
+      "linkColor": "#3498DB",
+      "background-color": "#F5F5F5",
+      "contentAreaBackgroundColor": "#FFFFFF",
+      "width": 600
+    },
+    "metadata": {
+      "lang": "en",
+      "title": "Welcome Newsletter",
+      "description": "Welcome email template for new subscribers",
+      "subject": "Welcome to Our Newsletter!",
+      "preheader": "Get started with our latest updates and tips"
+    }
+  }
+} 

--- a/partial-design-edits-concept/index.html
+++ b/partial-design-edits-concept/index.html
@@ -1,0 +1,1159 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>AI Email Creation Assistant</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* General Styles */
+      :root {
+        --primary: #7747FF;
+        --primary-rgb: 119, 71, 255;
+        --accent: #82EDA8;
+        --accent-rgb: 130, 237, 168;
+        --background: #FBF9FF;
+        --dark-bg: #26045D;
+        --light-shapes: #F1F0EE;
+        --body-text: #272D3D;
+        --alt-text: #140231;
+        --chat-bg: #FFFFFF;
+        --chat-border: #E5E7EB;
+        --user-message-bg: #7747FF;
+        --assistant-message-bg: #F3F4F6;
+        --user-message-text: #FFFFFF;
+        --assistant-message-text: #374151;
+      }
+      
+      * {
+        box-sizing: border-box;
+      }
+      
+      body {
+        font-family: 'Inter', sans-serif;
+        margin: 0;
+        padding: 0;
+        background-color: var(--background);
+        color: var(--body-text);
+        line-height: 1.6;
+        height: 100vh;
+        overflow: hidden;
+      }
+
+      .main-container {
+        display: flex;
+        height: 100vh;
+      }
+
+      /* Header Section */
+      .header-section {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 60px;
+        background-color: var(--chat-bg);
+        border-bottom: 1px solid var(--chat-border);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 20px;
+        z-index: 1000;
+      }
+
+      .header-title {
+        font-size: 1.2rem;
+        font-weight: 600;
+        color: var(--dark-bg);
+      }
+
+      .upload-section {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .upload-button {
+        background-color: var(--primary);
+        color: white;
+        border: none;
+        border-radius: 8px;
+        padding: 8px 16px;
+        font-size: 0.9rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: background-color 0.2s;
+      }
+
+      .upload-button:hover {
+        background-color: #6a3fe6;
+      }
+
+      .file-input {
+        display: none;
+      }
+
+      /* Modal Styles */
+      .modal {
+        display: none;
+        position: fixed;
+        z-index: 2000;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.5);
+      }
+
+      .modal-content {
+        background-color: var(--chat-bg);
+        margin: 5% auto;
+        padding: 30px;
+        border-radius: 12px;
+        width: 80%;
+        max-width: 600px;
+        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+      }
+
+      .modal-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 20px;
+      }
+
+      .modal-title {
+        font-size: 1.3rem;
+        font-weight: 600;
+        color: var(--dark-bg);
+        margin: 0;
+      }
+
+      .close-button {
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        cursor: pointer;
+        color: var(--body-text);
+        padding: 0;
+        width: 30px;
+        height: 30px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 50%;
+        transition: background-color 0.2s;
+      }
+
+      .close-button:hover {
+        background-color: var(--light-shapes);
+      }
+
+      .modal-body {
+        margin-bottom: 20px;
+      }
+
+      .modal-textarea {
+        width: 100%;
+        min-height: 300px;
+        padding: 15px;
+        border: 2px solid var(--chat-border);
+        border-radius: 8px;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+        font-size: 14px;
+        line-height: 1.4;
+        resize: vertical;
+        background-color: var(--background);
+      }
+
+      .modal-textarea:focus {
+        outline: none;
+        border-color: var(--primary);
+      }
+
+      .modal-footer {
+        display: flex;
+        justify-content: flex-end;
+        gap: 10px;
+      }
+
+      .modal-button {
+        padding: 10px 20px;
+        border: none;
+        border-radius: 8px;
+        font-size: 0.9rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: background-color 0.2s;
+      }
+
+      .modal-button.primary {
+        background-color: var(--primary);
+        color: white;
+      }
+
+      .modal-button.primary:hover {
+        background-color: #6a3fe6;
+      }
+
+      .modal-button.secondary {
+        background-color: var(--light-shapes);
+        color: var(--body-text);
+      }
+
+      .modal-button.secondary:hover {
+        background-color: #e5e5e5;
+      }
+
+      /* Chat Section */
+      .chat-section {
+        width: 33.33%;
+        background-color: var(--chat-bg);
+        border-right: 1px solid var(--chat-border);
+        display: flex;
+        flex-direction: column;
+        position: relative;
+        margin-top: 60px;
+        height: calc(100vh - 60px);
+      }
+
+      .chat-header {
+        padding: 20px;
+        border-bottom: 1px solid var(--chat-border);
+        background-color: var(--chat-bg);
+      }
+
+      .chat-header h1 {
+        margin: 0;
+        font-size: 1.3rem;
+        color: var(--dark-bg);
+        font-weight: 600;
+      }
+
+      .chat-header p {
+        margin: 5px 0 0 0;
+        color: var(--body-text);
+        font-size: 0.85rem;
+        opacity: 0.8;
+      }
+
+      .chat-messages {
+        flex: 1;
+        overflow-y: auto;
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .message {
+        max-width: 85%;
+        padding: 12px 16px;
+        border-radius: 18px;
+        font-size: 0.9rem;
+        line-height: 1.4;
+        word-wrap: break-word;
+      }
+
+      .message.user {
+        background-color: var(--user-message-bg);
+        color: var(--user-message-text);
+        align-self: flex-end;
+        margin-left: auto;
+      }
+
+      .message.assistant {
+        background-color: var(--assistant-message-bg);
+        color: var(--assistant-message-text);
+        align-self: flex-start;
+      }
+
+      .message.typing {
+        background-color: var(--assistant-message-bg);
+        color: var(--assistant-message-text);
+        align-self: flex-start;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .typing-dots {
+        display: flex;
+        gap: 4px;
+      }
+
+      .typing-dot {
+        width: 6px;
+        height: 6px;
+        background-color: var(--assistant-message-text);
+        border-radius: 50%;
+        animation: typing 1.4s infinite ease-in-out;
+      }
+
+      .typing-dot:nth-child(1) { animation-delay: -0.32s; }
+      .typing-dot:nth-child(2) { animation-delay: -0.16s; }
+
+      @keyframes typing {
+        0%, 80%, 100% { transform: scale(0.8); opacity: 0.5; }
+        40% { transform: scale(1); opacity: 1; }
+      }
+
+      .chat-input {
+        padding: 20px;
+        border-top: 1px solid var(--chat-border);
+        background-color: var(--chat-bg);
+      }
+
+      .input-container {
+        display: flex;
+        gap: 10px;
+        align-items: flex-end;
+      }
+
+      .input-field {
+        flex: 1;
+        border: 1px solid var(--chat-border);
+        border-radius: 12px;
+        padding: 12px 16px;
+        font-size: 0.9rem;
+        font-family: inherit;
+        resize: none;
+        min-height: 44px;
+        max-height: 120px;
+        outline: none;
+        transition: border-color 0.2s;
+      }
+
+      .input-field:focus {
+        border-color: var(--primary);
+      }
+
+      .send-button {
+        background-color: var(--primary);
+        color: white;
+        border: none;
+        border-radius: 12px;
+        padding: 12px 20px;
+        font-size: 0.9rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: background-color 0.2s;
+        min-width: 60px;
+      }
+
+      .send-button:hover {
+        background-color: #6a3fe6;
+      }
+
+      .send-button:disabled {
+        background-color: #ccc;
+        cursor: not-allowed;
+      }
+
+      /* Builder Section */
+      .builder-section {
+        width: 66.67%;
+        background-color: var(--background);
+        margin-top: 60px;
+        height: calc(100vh - 60px);
+        position: relative;
+      }
+
+      #bee-plugin-container {
+        width: 100%;
+        height: 100%;
+      }
+
+      .loading {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        font-size: 18px;
+        color: #666;
+      }
+
+      .error {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        font-size: 16px;
+        color: #d32f2f;
+        text-align: center;
+        max-width: 400px;
+      }
+
+      .hidden {
+        display: none;
+      }
+    </style>
+  </head>
+
+  <body>
+    <!-- Header Section -->
+    <div class="header-section">
+      <div class="header-title">AI Email Creation Assistant</div>
+      <div class="upload-section">
+        <input type="file" id="templateFile" class="file-input" accept=".json" />
+        <button class="upload-button" onclick="document.getElementById('templateFile').click()">
+          📁 Upload Template
+        </button>
+        <button class="upload-button" onclick="openPasteModal()">
+          📋 Paste Template JSON
+        </button>
+      </div>
+    </div>
+
+    <div class="main-container">
+      <!-- Chat Section -->
+      <div class="chat-section">
+        <div class="chat-header">
+          <h1>AI Assistant</h1>
+          <p>Chat with AI to edit your design</p>
+        </div>
+        
+        <div class="chat-messages" id="chatMessages">
+          <!-- Messages will be added here -->
+        </div>
+        
+        <div class="chat-input">
+          <div class="input-container">
+            <textarea 
+              class="input-field" 
+              id="userInput" 
+              placeholder="First save your design. Then, start chatting here to apply edits to parts of your design."
+              rows="1"
+            ></textarea>
+            <button class="send-button" id="sendButton" onclick="sendMessage()">
+              Send
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Builder Section -->
+      <div class="builder-section">
+        <div id="bee-plugin-container"></div>
+      </div>
+    </div>
+
+    <!-- Paste Template JSON Modal -->
+    <div id="pasteModal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title">Paste Template JSON</h3>
+          <button class="close-button" onclick="closePasteModal()">&times;</button>
+        </div>
+        <div class="modal-body">
+          <p style="margin-bottom: 15px; color: var(--body-text);">
+            Paste your full template JSON here. The JSON should be in the complete Beefree format with all styling and content.
+          </p>
+          <textarea 
+            id="jsonTextarea" 
+            class="modal-textarea" 
+            placeholder="Paste your template JSON here..."
+          ></textarea>
+        </div>
+        <div class="modal-footer">
+          <button class="modal-button secondary" onclick="closePasteModal()">Cancel</button>
+          <button class="modal-button primary" onclick="loadPastedTemplate()">Load Template</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Include the Beefree SDK -->
+    <script src="https://app-rsrc.getbee.io/plugin/BeePlugin.js"></script>
+
+    <script>
+      const chatMessages = document.getElementById('chatMessages');
+      const userInput = document.getElementById('userInput');
+      const sendButton = document.getElementById('sendButton');
+      const templateFile = document.getElementById('templateFile');
+      const pasteModal = document.getElementById('pasteModal');
+      const jsonTextarea = document.getElementById('jsonTextarea');
+
+      let isProcessing = false;
+      let beePluginInstance = null;
+      let currentTemplateData = null;
+      let hasBeenSaved = false;
+      let lastTemplateChange = null; // Store the latest template from onChange
+
+      // Initialize the chat
+      initializeChat();
+
+      // Handle Enter key in textarea
+      userInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          sendMessage();
+        }
+      });
+
+      // Auto-resize textarea
+      userInput.addEventListener('input', () => {
+        userInput.style.height = 'auto';
+        userInput.style.height = Math.min(userInput.scrollHeight, 120) + 'px';
+      });
+
+      // Handle file upload
+      templateFile.addEventListener('change', handleFileUpload);
+
+      function initializeChat() {
+        addMessage('assistant', 'First save your design. Then, start chatting here to apply edits to parts of your design.');
+      }
+
+      function handleFileUpload(event) {
+        const file = event.target.files[0];
+        if (!file) return;
+
+        const reader = new FileReader();
+        reader.onload = function(e) {
+          try {
+            const templateData = JSON.parse(e.target.result);
+            currentTemplateData = templateData;
+            
+            // Store in localStorage
+            localStorage.setItem('currentTemplate', JSON.stringify(templateData));
+            
+            // Load into Beefree SDK
+            if (beePluginInstance) {
+              beePluginInstance.start(templateData);
+              addMessage('assistant', '✅ Template uploaded and loaded successfully! You can now save it and start chatting to make edits.');
+            } else {
+              addMessage('assistant', '✅ Template uploaded! The editor will load it once ready.');
+            }
+          } catch (error) {
+            console.error('Error parsing template file:', error);
+            addMessage('assistant', '❌ Error: Invalid JSON file. Please check your template file.');
+          }
+        };
+        reader.readAsText(file);
+      }
+
+      // Modal functions for pasting template JSON
+      function openPasteModal() {
+        pasteModal.style.display = 'block';
+        jsonTextarea.value = '';
+        jsonTextarea.focus();
+      }
+
+      function closePasteModal() {
+        pasteModal.style.display = 'none';
+        jsonTextarea.value = '';
+      }
+
+      function loadPastedTemplate() {
+        const jsonText = jsonTextarea.value.trim();
+        if (!jsonText) {
+          alert('Please paste some JSON content first.');
+          return;
+        }
+
+        try {
+          const templateData = JSON.parse(jsonText);
+          currentTemplateData = templateData;
+          
+          // Store in localStorage
+          localStorage.setItem('currentTemplate', JSON.stringify(templateData));
+          
+          // Load into Beefree SDK
+          if (beePluginInstance) {
+            beePluginInstance.start(templateData);
+            addMessage('assistant', '✅ Template pasted and loaded successfully! You can now save it and start chatting to make edits.');
+          } else {
+            addMessage('assistant', '✅ Template pasted! The editor will load it once ready.');
+          }
+          
+          // Close the modal
+          closePasteModal();
+        } catch (error) {
+          console.error('Error parsing pasted JSON:', error);
+          alert('❌ Error: Invalid JSON format. Please check your template JSON and try again.');
+        }
+      }
+
+      // Close modal when clicking outside of it
+      window.onclick = function(event) {
+        if (event.target === pasteModal) {
+          closePasteModal();
+        }
+      }
+
+      function sendMessage() {
+        if (isProcessing) return;
+        
+        const message = userInput.value.trim();
+        if (!message) return;
+
+        if (!hasBeenSaved) {
+          addMessage('assistant', 'Please save your design first by clicking the Save button in the editor, then try chatting again.');
+          userInput.value = '';
+          userInput.style.height = 'auto';
+          return;
+        }
+
+        addMessage('user', message);
+        userInput.value = '';
+        userInput.style.height = 'auto';
+        
+        processEditRequest(message);
+      }
+
+      async function processEditRequest(userRequest) {
+        isProcessing = true;
+        sendButton.disabled = true;
+        showTypingIndicator();
+        
+        let updatedFullJson; // Declare the variable here
+
+        try {
+          // Step 1: Get the full JSON template from onChange (clean data)
+          addMessage('assistant', '🔄 Loading your current template...');
+          
+          // Use the clean template data from onChange if available, otherwise fall back to localStorage
+          let fullTemplate;
+          if (lastTemplateChange) {
+            console.log('Using clean template data from onChange');
+            fullTemplate = lastTemplateChange;
+          } else {
+            console.log('Falling back to localStorage template');
+            const currentTemplate = localStorage.getItem('currentTemplate');
+            if (!currentTemplate) {
+              throw new Error('No template found. Please upload or create a template first.');
+            }
+            
+            try {
+              fullTemplate = JSON.parse(currentTemplate);
+            } catch (error) {
+              console.error('Error parsing template from localStorage:', error);
+              throw new Error('Invalid template data in localStorage');
+            }
+          }
+          
+          console.log('Full template loaded:', fullTemplate);
+
+          // Step 2: Convert full JSON to simple JSON using Beefree API
+          addMessage('assistant', '🔄 Converting template to simple format...');
+          console.log('Converting full JSON to simple JSON...');
+          console.log('Full template type:', typeof fullTemplate);
+          console.log('Full template keys:', Object.keys(fullTemplate || {}));
+          
+          // If fullTemplate is already a string, parse it first
+          let templateToSend = fullTemplate;
+          if (typeof fullTemplate === 'string') {
+            try {
+              templateToSend = JSON.parse(fullTemplate);
+            } catch (error) {
+              console.error('Error parsing template string:', error);
+              throw new Error('Invalid template data format');
+            }
+          }
+          
+          const simpleResponse = await fetch('/api/beefree/full-to-simple', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(templateToSend)
+          });
+
+          if (!simpleResponse.ok) {
+            const errorData = await simpleResponse.text();
+            console.error('Beefree full-to-simple API error:', errorData);
+            throw new Error(`Failed to convert template: ${simpleResponse.status} ${simpleResponse.statusText}`);
+          }
+
+          const simpleData = await simpleResponse.json();
+          console.log('Simple JSON received from Beefree:', simpleData);
+          
+          // Small delay to show the conversion step
+          await new Promise(resolve => setTimeout(resolve, 1000));
+
+          // Step 3: Call Anthropic API with instructions, prompt, schema reference, simple JSON, and user request
+          addMessage('assistant', '🤖 AI is analyzing your request and making changes...');
+          console.log('Calling Anthropic API with edit request...');
+          
+          // Load the unified schema for reference
+          const schemaResponse = await fetch('/simple_unified.schema.json');
+          const unifiedSchema = await schemaResponse.json();
+          
+          // Calculate template size and determine if we need special handling
+          const templateSize = JSON.stringify(simpleData, null, 2).length;
+          const isLargeTemplate = templateSize > 10000; // 10k+ chars needs special handling
+          
+          let templateToShow = simpleData;
+          let sizeWarning = '';
+          
+          if (isLargeTemplate) {
+            sizeWarning = `🚨 CRITICAL WARNING: This template has ${templateSize} characters. DO NOT RECREATE THE ENTIRE TEMPLATE - THIS WILL CAUSE ERRORS AND TRUNCATION.`;
+          }
+
+          const anthropicPrompt = `🚨 CRITICAL: YOU MUST RETURN A COMPLETE, VALID JSON RESPONSE
+
+TEMPLATE SIZE: ${templateSize} characters (${Math.round(templateSize/50)} lines approx.)
+${isLargeTemplate ? '⚠️ THIS IS A LARGE TEMPLATE - DO NOT RECREATE IT!' : ''}
+
+🎯 YOUR TASK:
+1. Take the existing simple JSON template provided below
+2. Apply ONLY the user's requested edit: "${userRequest}"
+3. Return the COMPLETE template with the edit applied
+4. Ensure the response is VALID JSON that follows simple_template.schema.json
+
+📋 SCHEMA REFERENCE:
+You must follow the simple_unified.schema.json structure:
+- Root: {"template": {...}}
+- Required: "rows" array with at least 1 row
+- Each row needs: "name" (string) and "columns" (array)
+- Each column needs: "weight" (1-12) and "modules" (array)
+- Valid module types: title, paragraph, button, image, divider, html, list, menu, icons
+
+🔴 CRITICAL RULES:
+1. DO NOT RECREATE the template - edit the existing one
+2. DO NOT truncate or cut off the JSON response
+3. DO NOT include markdown formatting (no \`\`\`json blocks)
+4. DO NOT add properties not in the schema
+5. PRESERVE all existing content except what needs to be edited
+
+✅ EDITING APPROACH:
+- If user says "add X": Find the appropriate location and ADD X
+- If user says "change Y to Z": Find Y and CHANGE only that to Z
+- If user says "remove X": Find X and REMOVE only that
+- Everything else stays EXACTLY the same
+
+🚫 FORBIDDEN PROPERTIES:
+- "locked", "uuid", "descriptor", "computedStyle"
+- "href" or "target" for images
+- Complex "link" objects in menu items
+- Any property not defined in the schema
+
+⚠️ RESPONSE SIZE PRIORITY:
+This is your TOP PRIORITY - you MUST return the COMPLETE JSON, even for templates up to 2000 lines.
+To ensure this:
+1. Make MINIMAL edits only
+2. Don't add unnecessary formatting or properties
+3. Focus on the specific change requested
+4. Keep your response efficient
+
+EXISTING TEMPLATE TO EDIT:
+${JSON.stringify(templateToShow, null, 2)}
+
+USER REQUEST: "${userRequest}"
+
+📋 SIMPLE MODULE EXAMPLES:
+PARAGRAPH: {"type": "paragraph", "text": "content", "align": "center", "size": 16, "color": "#000000"}
+TITLE: {"type": "title", "text": "title text", "align": "center", "size": 24, "color": "#000000"}  
+BUTTON: {"type": "button", "text": "button text", "href": "https://example.com", "align": "center", "color": "#ffffff", "background-color": "#0066CC"}
+IMAGE: {"type": "image", "src": "https://example.com/image.jpg", "alt": "description"}
+DIVIDER: {"type": "divider"}
+
+NEW ROW: {"name": "Row Name", "columns": [{"weight": 12, "modules": [/* modules */]}]}
+
+🔧 ERROR HANDLING:
+If the first API call fails, you'll receive detailed Beefree SDK error messages.
+These errors are specific and helpful - use them to fix ONLY the validation issues.
+
+📝 FINAL OUTPUT:
+Return ONLY the complete JSON object - no markdown, no explanations.
+The JSON must be parseable by JSON.parse() and valid according to simple_template.schema.json.
+
+REMEMBER: Your #1 priority is returning a COMPLETE, VALID JSON response up to 2000 lines.`;
+
+          const anthropicResponse = await fetch('/api/anthropic', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              prompt: anthropicPrompt
+            })
+          });
+
+          if (!anthropicResponse.ok) {
+            const errorData = await anthropicResponse.text();
+            console.error('Anthropic API error:', errorData);
+            throw new Error(`Failed to process edit request: ${anthropicResponse.status} ${anthropicResponse.statusText}`);
+          }
+
+          const anthropicData = await anthropicResponse.json();
+          console.log('Anthropic API response:', anthropicData);
+          
+          // Extract the updated simple JSON from Anthropic response
+          let updatedSimpleJsonText = '';
+          if (anthropicData.content && anthropicData.content.length > 0) {
+            const textBlock = anthropicData.content.find(block => block.type === 'text');
+            if (textBlock) {
+              updatedSimpleJsonText = textBlock.text;
+            } else {
+              throw new Error('No text content found in Anthropic API response');
+            }
+          } else {
+            throw new Error('Invalid response structure from Anthropic API');
+          }
+
+          console.log('Raw Anthropic response text:', updatedSimpleJsonText);
+
+          // Parse the updated simple JSON
+          let updatedSimpleJson;
+          try {
+            // Try to find JSON in code blocks first
+            const jsonMatch = updatedSimpleJsonText.match(/```json\s*([\s\S]*?)\s*```/) || 
+                             updatedSimpleJsonText.match(/```\s*([\s\S]*?)\s*```/);
+            
+            if (jsonMatch) {
+              updatedSimpleJson = JSON.parse(jsonMatch[1]);
+            } else {
+              // If no code blocks, try to parse the entire text as JSON
+              updatedSimpleJson = JSON.parse(updatedSimpleJsonText.trim());
+            }
+            
+            console.log('Updated simple JSON parsed:', updatedSimpleJson);
+          
+          // Validate that the AI returned a proper template structure
+          if (!updatedSimpleJson.template) {
+            throw new Error('AI response missing template property. Please ensure the AI returns a complete template object.');
+          }
+          
+          // Small delay to show the AI processing step
+          await new Promise(resolve => setTimeout(resolve, 1000));
+            
+          } catch (parseError) {
+            console.error('JSON parsing error:', parseError);
+            console.error('Raw response text:', updatedSimpleJsonText);
+            throw new Error(`Invalid JSON format in response: ${parseError.message}`);
+          }
+
+          // Step 4: Convert updated simple JSON to full JSON using Beefree API
+          addMessage('assistant', '🔄 Converting changes back to full template format...');
+          console.log('Converting updated simple JSON to full JSON...');
+          
+          const fullResponse = await fetch('/api/beefree/simple-to-full', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(updatedSimpleJson)
+          });
+
+          if (!fullResponse.ok) {
+            const errorData = await fullResponse.text();
+            console.error('Beefree simple-to-full API error:', errorData);
+            
+            // Parse the error details for feedback
+            let errorDetails = '';
+            try {
+              const errorJson = JSON.parse(errorData);
+              errorDetails = errorJson.details || errorData;
+            } catch (e) {
+              errorDetails = errorData;
+            }
+            
+            // Send error feedback to Anthropic for correction
+            addMessage('assistant', 'I need to fix some formatting issues. Let me correct the template...');
+            
+            const correctionPrompt = `🔧 ERROR CORRECTION - FIX VALIDATION ERRORS ONLY
+
+TEMPLATE SIZE: ${JSON.stringify(simpleData, null, 2).length} characters
+⚠️ DO NOT RECREATE - ONLY FIX THE SPECIFIC ERRORS
+
+BEEFREE SDK VALIDATION ERRORS:
+${errorDetails}
+
+USER'S ORIGINAL REQUEST: "${userRequest}"
+
+🎯 YOUR TASK:
+1. Take the original template below
+2. Fix ONLY the properties causing validation errors
+3. Keep everything else EXACTLY the same
+4. Return the COMPLETE corrected template
+
+ORIGINAL TEMPLATE TO FIX:
+${JSON.stringify(simpleData, null, 2)}
+
+📋 COMMON ERRORS TO FIX:
+- Invalid properties: "locked", "uuid", "descriptor", "computedStyle"
+- Wrong property names (e.g., "href" on images, complex "link" objects)
+- Missing required properties (name, columns, weight, modules)
+- Invalid module types or structures
+
+🔧 FIX STRATEGY:
+- Remove forbidden properties
+- Fix property names
+- Add missing required properties
+- Keep ALL other content exactly the same
+
+📝 FINAL OUTPUT:
+Return ONLY the complete corrected JSON - no markdown, no explanations.
+The JSON must be valid according to simple_template.schema.json.
+
+REMEMBER: Fix ONLY the validation errors. Everything else stays the same.`;
+
+            // Call Anthropic API again with correction prompt
+            const correctionResponse = await fetch('/api/anthropic', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify({
+                prompt: correctionPrompt
+              })
+            });
+
+            if (!correctionResponse.ok) {
+              const correctionErrorData = await correctionResponse.text();
+              console.error('Anthropic correction API error:', correctionErrorData);
+              throw new Error(`Failed to get correction: ${correctionResponse.status} ${correctionResponse.statusText}`);
+            }
+
+            const correctionData = await correctionResponse.json();
+            console.log('Anthropic correction API response:', correctionData);
+            
+            // Extract the corrected simple JSON from Anthropic response
+            let correctedSimpleJsonText = '';
+            if (correctionData.content && correctionData.content.length > 0) {
+              const textBlock = correctionData.content.find(block => block.type === 'text');
+              if (textBlock) {
+                correctedSimpleJsonText = textBlock.text;
+              } else {
+                throw new Error('No text content found in Anthropic correction API response');
+              }
+            } else {
+              throw new Error('Invalid response structure from Anthropic correction API');
+            }
+
+            console.log('Raw Anthropic correction response text:', correctedSimpleJsonText);
+
+            // Parse the corrected simple JSON
+            let correctedSimpleJson;
+            try {
+              // Try to find JSON in code blocks first
+              const jsonMatch = correctedSimpleJsonText.match(/```json\s*([\s\S]*?)\s*```/) || 
+                               correctedSimpleJsonText.match(/```\s*([\s\S]*?)\s*```/);
+              
+              if (jsonMatch) {
+                correctedSimpleJson = JSON.parse(jsonMatch[1]);
+              } else {
+                // Try to parse the entire response as JSON
+                correctedSimpleJson = JSON.parse(correctedSimpleJsonText);
+              }
+            } catch (parseError) {
+              console.error('Corrected JSON parsing error:', parseError);
+              console.error('Raw correction response text:', correctedSimpleJsonText);
+              throw new Error(`Invalid JSON format in correction response: ${parseError.message}`);
+            }
+
+            console.log('Corrected simple JSON:', correctedSimpleJson);
+
+            // Try the simple-to-full conversion again with the corrected template
+            addMessage('assistant', '🔄 Converting corrected template to full format...');
+            
+            const correctedFullResponse = await fetch('/api/beefree/simple-to-full', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify(correctedSimpleJson)
+            });
+
+            if (!correctedFullResponse.ok) {
+              const correctedErrorData = await correctedFullResponse.text();
+              console.error('Beefree corrected simple-to-full API error:', correctedErrorData);
+              throw new Error(`Failed to convert corrected template: ${correctedFullResponse.status} ${correctedFullResponse.statusText}`);
+            }
+
+            updatedFullJson = await correctedFullResponse.json();
+            console.log('Updated full JSON from Beefree (corrected):', updatedFullJson);
+          } else {
+            updatedFullJson = await fullResponse.json();
+            console.log('Updated full JSON from Beefree:', updatedFullJson);
+          }
+
+          // Step 5: Store the updated full JSON and load it in the builder
+          addMessage('assistant', '🔄 Loading updated template into the editor...');
+          
+          // Store the clean template data
+          lastTemplateChange = updatedFullJson;
+          currentTemplateData = updatedFullJson;
+          localStorage.setItem('currentTemplate', JSON.stringify(updatedFullJson));
+
+          // Load the updated template into the Beefree SDK editor
+          if (beePluginInstance) {
+            beePluginInstance.start(updatedFullJson);
+          }
+
+          // Display success message
+          hideTypingIndicator();
+          addMessage('assistant', '✅ Your design has been updated successfully! The changes have been applied to your template.');
+
+        } catch (error) {
+          console.error('Error processing edit request:', error);
+          hideTypingIndicator();
+          addMessage('assistant', `❌ Sorry, there was an error applying your changes: ${error.message}`);
+        } finally {
+          isProcessing = false;
+          sendButton.disabled = false;
+        }
+      }
+
+      function addMessage(sender, text) {
+        const messageDiv = document.createElement('div');
+        messageDiv.className = `message ${sender}`;
+        messageDiv.textContent = text;
+        chatMessages.appendChild(messageDiv);
+        chatMessages.scrollTop = chatMessages.scrollHeight;
+      }
+
+      function showTypingIndicator() {
+        const typingDiv = document.createElement('div');
+        typingDiv.className = 'message typing';
+        typingDiv.id = 'typing-indicator';
+        typingDiv.innerHTML = `
+          <span>AI is working on applying your edits to your design</span>
+          <div class="typing-dots">
+            <div class="typing-dot"></div>
+            <div class="typing-dot"></div>
+            <div class="typing-dot"></div>
+          </div>
+        `;
+        chatMessages.appendChild(typingDiv);
+        chatMessages.scrollTop = chatMessages.scrollHeight;
+      }
+
+      function hideTypingIndicator() {
+        const typingIndicator = document.getElementById('typing-indicator');
+        if (typingIndicator) {
+          typingIndicator.remove();
+        }
+      }
+
+      // Beefree configuration
+      const beeConfig = {
+        container: 'bee-plugin-container',
+        uid: 'demo-user-' + Date.now(),
+        language: 'en-US',
+        trackChanges: true, // Enable onChange tracking
+        specialLinks: [
+          {
+            type: "unsubscribe",
+            label: "Unsubscribe",
+            link: "http://[unsubscribe]/",
+          },
+          {
+            type: "subscribe",
+            label: "Subscribe",
+            link: "http://[subscribe]/",
+          },
+        ],
+        mergeTags: [
+          {
+            name: "First Name",
+            value: "[first_name]",
+          },
+          {
+            name: "Last Name",
+            value: "[last_name]",
+          },
+          {
+            name: "Email",
+            value: "[email]",
+          },
+        ],
+        onSave: function (jsonFile, htmlFile) {
+          console.log("Template saved:", jsonFile);
+          
+          // Store the saved template
+          localStorage.setItem('currentTemplate', JSON.stringify(jsonFile));
+          currentTemplateData = jsonFile;
+          
+          // Mark as saved so user can start chatting
+          hasBeenSaved = true;
+          
+          // Show success message in chat
+          addMessage('assistant', '✅ Design saved successfully! You can now start chatting to apply edits to your design.');
+          
+          // Update the placeholder text
+          userInput.placeholder = "Describe the changes you'd like AI to apply to your design. Include the location of where AI should apply these changes in your design. For example: \"Rewrite the paragraph in row 3 column 2\" or \"Add another row promoting our latest blog posts at the end of the design. The three we want to promote are Simple Schema: @https://developers.beefree.io/blog/simple-schema-a-streamlined-path-to-ai-powered-email-creation-with-beefree-sdk ,   Build and SDK Developer Love: @https://developers.beefree.io/blog/best-practices-for-ai-integrations-and-customization , and Reusable Content: @https://developers.beefree.io/blog/save-and-reuse-content-blocks \"";
+        },
+        onChange: function (jsonFile, response) {
+          console.log("Template changed:", jsonFile);
+          console.log("Change response:", response);
+          
+          // Store the clean template data directly from onChange (no stringification)
+          lastTemplateChange = jsonFile;
+          currentTemplateData = jsonFile;
+          
+          // Also store in localStorage for persistence (but this is the clean version)
+          localStorage.setItem('currentTemplate', JSON.stringify(jsonFile));
+        },
+
+        onSend: function (htmlFile) {
+          console.log("Email ready to send:", htmlFile);
+        },
+        onError: function (errorMessage) {
+          console.error("Beefree SDK error:", errorMessage);
+          document.getElementById('bee-plugin-container').innerHTML = 
+            '<div class="error">Error loading Beefree SDK: ' + errorMessage.message + '</div>';
+        }
+      };
+
+      // Function to get Beefree token using our proxy
+      function getBeeToken(callback) {
+        fetch('/api/beefree/auth', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            client_id: 'fa75c918-7634-4313-849b-8ae79632ebc0',
+            client_secret: 'NVWjIkIwQRXRBUqJSXAKCTVpjB1539Qo5pEY9jBeA5i2CbqaFgMS',
+            uid: beeConfig.uid
+          })
+        })
+        .then(response => {
+          if (!response.ok) throw new Error('Auth failed: ' + response.status);
+          return response.json();
+        })
+        .then(data => {
+          callback(data);
+        })
+        .catch(error => {
+          console.error('Error getting Beefree token:', error);
+          document.getElementById('bee-plugin-container').innerHTML = 
+            '<div class="error">Failed to authenticate with Beefree. Please check your credentials and try again.</div>';
+        });
+      }
+
+      // Initialize Beefree SDK
+      function initializeBeefree(authResponse) {
+        BeePlugin.create(authResponse, beeConfig, function (beePlugin) {
+          console.log('Beefree SDK initialized successfully');
+          beePluginInstance = beePlugin;
+          
+          // Check if we have a template to load
+          const savedTemplate = localStorage.getItem('currentTemplate');
+          if (savedTemplate) {
+            try {
+              const templateData = JSON.parse(savedTemplate);
+              beePlugin.start(templateData);
+              currentTemplateData = templateData;
+              console.log('Loaded saved template');
+            } catch (error) {
+              console.error('Error loading saved template:', error);
+              beePlugin.start();
+            }
+          } else {
+            // Start with empty template
+            beePlugin.start();
+            console.log('Started with empty template');
+          }
+        });
+      }
+
+      // Start the initialization process
+      getBeeToken(initializeBeefree);
+    </script>
+  </body>
+</html>

--- a/partial-design-edits-concept/package.json
+++ b/partial-design-edits-concept/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "beefree-partial-design-edits",
+    "version": "1.0.0",
+    "description": "AI-powered partial design editing with Beefree SDK",
+    "main": "index.html",
+    "scripts": {
+        "start": "node proxy-server.js",
+        "dev": "node proxy-server.js",
+        "serve": "serve"
+    },
+    "keywords": [
+        "beefree",
+        "email",
+        "ai",
+        "design",
+        "editing"
+    ],
+    "author": "Beefree SDK Team",
+    "license": "MIT",
+    "devDependencies": {
+        "serve": "11.2.0"
+    },
+    "dependencies": {
+        "axios": "^1.11.0",
+        "cors": "^2.8.5",
+        "express": "^5.1.0",
+        "node-fetch": "^2.7.0"
+    }
+}

--- a/partial-design-edits-concept/proxy-server.js
+++ b/partial-design-edits-concept/proxy-server.js
@@ -1,0 +1,202 @@
+const express = require('express');
+const cors = require('cors');
+const fetch = require('node-fetch');
+const path = require('path');
+
+const app = express();
+const PORT = 3000;
+
+// Middleware
+app.use(cors());
+app.use(express.json());
+app.use(express.static(path.join(__dirname)));
+
+// Load credentials
+const credentials = require('./credentials.js');
+
+// Health check endpoint
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok', message: 'Proxy server is running' });
+});
+
+// Proxy endpoint for Anthropic API
+app.post('/api/anthropic', async (req, res) => {
+  console.log('Received Anthropic API request:', req.body);
+  try {
+    const { prompt } = req.body;
+    
+    if (!prompt) {
+      console.log('No prompt provided');
+      return res.status(400).json({ error: 'Prompt is required' });
+    }
+
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': credentials.anthropic_api_key,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 16000,
+        messages: [{
+          role: 'user',
+          content: prompt
+        }]
+      })
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      console.error('Anthropic API error:', errorData);
+      return res.status(response.status).json({ 
+        error: `Anthropic API error: ${response.status} ${response.statusText}`,
+        details: errorData
+      });
+    }
+
+    const data = await response.json();
+    res.json(data);
+    
+  } catch (error) {
+    console.error('Proxy server error:', error);
+    res.status(500).json({ error: 'Internal server error', details: error.message });
+  }
+});
+
+// Proxy endpoint for Beefree API - Authentication (V2)
+app.post('/api/beefree/auth', async (req, res) => {
+  try {
+    const { client_id, client_secret, uid } = req.body;
+    
+    if (!client_id || !client_secret || !uid) {
+      return res.status(400).json({ error: 'client_id, client_secret, and uid are required' });
+    }
+
+    const response = await fetch('https://auth.getbee.io/loginV2', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        client_id: client_id,
+        client_secret: client_secret,
+        uid: uid
+      })
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      console.error('Beefree auth error:', errorData);
+      return res.status(response.status).json({ 
+        error: `Beefree auth error: ${response.status} ${response.statusText}`,
+        details: errorData
+      });
+    }
+
+    const data = await response.json();
+    console.log('Beefree auth response:', data);
+    res.json(data);
+    
+  } catch (error) {
+    console.error('Proxy server error:', error);
+    res.status(500).json({ error: 'Internal server error', details: error.message });
+  }
+});
+
+// Proxy endpoint for Beefree API - Simple to Full JSON
+app.post('/api/beefree/simple-to-full', async (req, res) => {
+  try {
+    // Handle both formats: { template: ... } and direct template object
+    let template;
+    if (req.body.template) {
+      template = req.body.template;
+    } else {
+      template = req.body;
+    }
+    
+    if (!template) {
+      return res.status(400).json({ error: 'Template is required' });
+    }
+
+    console.log('Beefree simple-to-full request body:', JSON.stringify({ template }, null, 2));
+
+    const response = await fetch('https://api.getbee.io/v1/conversion/simple-to-full-json', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${credentials.beefree_api_key}`
+      },
+      body: JSON.stringify({ template })
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      console.error('Beefree API error (simple-to-full):', errorData);
+      return res.status(response.status).json({ 
+        error: `Beefree API error: ${response.status} ${response.statusText}`,
+        details: errorData
+      });
+    }
+
+    const data = await response.json();
+    res.json(data);
+    
+  } catch (error) {
+    console.error('Proxy server error:', error);
+    res.status(500).json({ error: 'Internal server error', details: error.message });
+  }
+});
+
+// Proxy endpoint for Beefree API - Full to Simple JSON
+app.post('/api/beefree/full-to-simple', async (req, res) => {
+  try {
+    // Handle both formats: direct template object or wrapped
+    let template = req.body;
+    
+    console.log('Received full template for conversion to simple JSON');
+    console.log('Request body type:', typeof req.body);
+    console.log('Request body keys:', Object.keys(req.body || {}));
+    
+    if (!template) {
+      return res.status(400).json({ error: 'Template is required' });
+    }
+
+    const response = await fetch('https://api.getbee.io/v1/conversion/full-to-simple-json', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${credentials.beefree_api_key}`
+      },
+      body: JSON.stringify(template)
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      console.error('Beefree API error (full-to-simple):', errorData);
+      return res.status(response.status).json({ 
+        error: `Beefree API error: ${response.status} ${response.statusText}`,
+        details: errorData
+      });
+    }
+
+    const data = await response.json();
+    res.json(data);
+    
+  } catch (error) {
+    console.error('Proxy server error:', error);
+    res.status(500).json({ error: 'Internal server error', details: error.message });
+  }
+});
+
+// Start server
+app.listen(PORT, () => {
+  console.log(`Proxy server running on http://localhost:${PORT}`);
+  console.log('Available endpoints:');
+  console.log('  GET  /api/health');
+  console.log('  POST /api/anthropic');
+  console.log('  POST /api/beefree/auth');
+  console.log('  POST /api/beefree/simple-to-full');
+  console.log('  POST /api/beefree/full-to-simple');
+});

--- a/partial-design-edits-concept/simple_button.schema.json
+++ b/partial-design-edits-concept/simple_button.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "simple_button.schema.json",
+  "title": "Simple Button",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "button"
+    },
+    "label": {
+      "type": "string",
+      "format": "noAnchorTags"
+    },
+    "text": {
+      "type": "string",
+      "format": "noAnchorTags"
+    },
+    "align": {
+      "enum": [
+        "left",
+        "center",
+        "right"
+      ]
+    },
+    "href": {
+      "type": "string"
+    },
+    "target": {
+      "enum": [
+        "_blank",
+        "_self",
+        "_top"
+      ]
+    },
+    "size": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "color": {
+      "type": "string"
+    },
+    "background-color": {
+      "type": "string"
+    },
+    "padding-top": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "padding-right": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "padding-bottom": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "padding-left": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "contentPaddingTop": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "contentPaddingRight": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "contentPaddingLeft": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "contentPaddingBottom": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "hoverBackgroundColor": {
+      "type": "string"
+    },
+    "hoverColor": {
+      "type": "string"
+    },
+    "hoverBorderColor": {
+      "type": "string"
+    },
+    "hoverBorderWidth": {
+      "$ref": "definitions.schema.json#/definitions/borderWidth"
+    },
+    "locked": {
+      "type": "boolean"
+    },
+    "border-radius": {
+      "$ref": "definitions.schema.json#/definitions/borderRadius"
+    },
+    "border-color": {
+      "type": "string"
+    },
+    "border-width": {
+      "$ref": "definitions.schema.json#/definitions/borderWidth"
+    },
+    "customFields": {
+      "type": "object"
+    }
+  }
+}

--- a/partial-design-edits-concept/simple_column.schema.json
+++ b/partial-design-edits-concept/simple_column.schema.json
@@ -1,0 +1,89 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "simple_column.schema.json",
+    "title": "Simple Column",
+    "type": "object",
+    "required": [
+      "weight",
+      "modules"
+    ],
+    "additionalProperties": false,
+    "properties": {
+      "weight": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 12
+      },
+      "background-color": {
+        "type": "string"
+      },
+      "padding-top": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-right": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-bottom": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-left": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "border-color": {
+        "type": "string"
+      },
+      "border-width": {
+        "$ref": "definitions.schema.json#/definitions/borderWidth"
+      },
+      "modules": {
+        "type": "array",
+        "minItems": 0,
+        "items": {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "discriminator": {
+            "propertyName": "type"
+          },
+          "properties": {
+            "type": {
+              "$ref": "definitions.schema.json#/definitions/typeOfModules"
+            }
+          },
+          "oneOf": [
+            {
+              "$ref": "simple_button.schema.json"
+            },
+            {
+              "$ref": "simple_divider.schema.json"
+            },
+            {
+              "$ref": "simple_html.schema.json"
+            },
+            {
+              "$ref": "simple_icons.schema.json"
+            },
+            {
+              "$ref": "simple_image.schema.json"
+            },
+            {
+              "$ref": "simple_list.schema.json"
+            },
+            {
+              "$ref": "simple_menu.schema.json"
+            },
+            {
+              "$ref": "simple_paragraph.schema.json"
+            },
+            {
+              "$ref": "simple_title.schema.json"
+            }
+          ]
+        }
+      },
+      "customFields": {
+        "type": "object"
+      }
+    }
+  }

--- a/partial-design-edits-concept/simple_divider.schema.json
+++ b/partial-design-edits-concept/simple_divider.schema.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "simple_divider.schema.json",
+    "title": "Simple Divider",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "type": {
+        "const": "divider"
+      },
+      "color":{
+        "type": "string"
+      },
+       "height": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 30
+      },
+      "width": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 100
+      },
+      "padding-top": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-right": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-bottom": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-left": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "locked": {
+        "type": "boolean"
+      },
+      "customFields": {
+        "type": "object"
+      }
+    }
+  }

--- a/partial-design-edits-concept/simple_html.schema.json
+++ b/partial-design-edits-concept/simple_html.schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "simple_html.schema.json",
+    "title": "Simple Html",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "type": {
+        "const": "html"
+      },
+      "html": {
+        "type": "string"
+      },
+      "customFields": {
+        "type": "object"
+      },
+      "locked": {
+        "type": "boolean"
+      }
+    }
+  }

--- a/partial-design-edits-concept/simple_icons.schema.json
+++ b/partial-design-edits-concept/simple_icons.schema.json
@@ -1,0 +1,83 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "simple_icons.schema.json",
+    "title": "Simple Icons",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "type": {
+        "const": "icons"
+      },
+      "icons": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "image",
+            "textPosition",
+            "width",
+            "height"
+          ],
+          "properties": {
+            "alt": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "image": {
+              "type": "string",
+              "format": "urlOrMergeTags"
+            },
+            "href": {
+              "type": "string",
+              "format": "urlOrMergeTagsOrEmpty"
+            },
+            "height": {
+              "type": "string"
+            },
+            "width": {
+              "type": "string"
+            },
+            "target": {
+              "enum": [
+                "_blank",
+                "_self",
+                "_top"
+              ]
+            },
+            "textPosition": {
+              "enum": [
+                "left",
+                "right",
+                "top",
+                "bottom"
+              ]
+            }
+          }
+        }
+      },
+      "padding-top": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-right": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-bottom": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-left": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "locked": {
+        "type": "boolean"
+      },
+      "customFields": {
+        "type": "object"
+      }
+    }
+  }

--- a/partial-design-edits-concept/simple_image.schema.json
+++ b/partial-design-edits-concept/simple_image.schema.json
@@ -1,0 +1,50 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "simple_image.schema.json",
+    "title": "Simple Image",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "type": {
+        "const": "image"
+      },
+      "alt": {
+        "type": "string"
+      },
+      "href": {
+        "type": "string"
+      },
+      "src": {
+        "type": "string",
+        "format": "urlOrMergeTags"
+      },
+      "dynamicSrc": {
+        "type": "string"
+      },
+      "target": {
+        "enum": [
+          "_blank",
+          "_self",
+          "_top"
+        ]
+      },
+      "padding-top": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-right": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-bottom": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-left": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "locked": {
+        "type": "boolean"
+      },
+      "customFields": {
+        "type": "object"
+      }
+    }
+  }

--- a/partial-design-edits-concept/simple_list.schema.json
+++ b/partial-design-edits-concept/simple_list.schema.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "simple_list.schema.json",
+    "title": "Simple List",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "type": {
+        "const": "list"
+      },
+      "underline": {
+        "type": "boolean"
+      },
+      "italic": {
+        "type": "boolean"
+      },
+      "bold": {
+        "type": "boolean"
+      },
+      "html": {
+        "type": "string"
+      },
+      "text": {
+        "type": "string"
+      },
+      "align": {
+        "enum": [
+          "left",
+          "center",
+          "right"
+        ]
+      },
+      "tag": {
+        "enum": [
+          "ol",
+          "ul"
+        ]
+      },
+      "size": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "color": {
+        "type": "string"
+      },
+      "linkColor": {
+        "type": "string"
+      },
+      "letter-spacing": {
+        "type": "integer",
+        "minimum": -99,
+        "maximum": 99
+      },
+      "line-height": {
+        "type": "number",
+        "minimum": 0.5,
+        "maximum": 3,
+        "multipleOf": 0.00001
+      },
+      "padding-top": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-right": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-bottom": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-left": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "locked": {
+        "type": "boolean"
+      },
+      "direction": {
+        "enum": [
+          "ltr",
+          "rtl"
+        ]
+      },
+      "customFields": {
+        "type": "object"
+      }
+    }
+  }

--- a/partial-design-edits-concept/simple_menu.schema.json
+++ b/partial-design-edits-concept/simple_menu.schema.json
@@ -1,0 +1,65 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "simple_menu.schema.json",
+    "title": "Simple Menu",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "type": {
+        "const": "menu"
+      },
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "const": "menu-item"
+            },
+            "text": {
+              "type": "string"
+            },
+            "link": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "href": {
+                  "type": "string",
+                  "format": "urlOrMergeTagsOrEmpty"
+                },
+                "target": {
+                  "enum": [
+                    "_blank",
+                    "_self",
+                    "_top"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "padding-top": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-right": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-bottom": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-left": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "locked": {
+        "type": "boolean"
+      },
+      "customFields": {
+        "type": "object"
+      }
+    }
+  }

--- a/partial-design-edits-concept/simple_paragraph.schema.json
+++ b/partial-design-edits-concept/simple_paragraph.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "simple_paragraph.schema.json",
+  "title": "Simple Paragraph",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "paragraph"
+    },
+    "underline": {
+      "type": "boolean"
+    },
+    "italic": {
+      "type": "boolean"
+    },
+    "bold": {
+      "type": "boolean"
+    },
+    "html": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    },
+    "align": {
+      "enum": [
+        "left",
+        "center",
+        "right",
+        "justify"
+      ]
+    },
+    "size": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "color": {
+      "type": "string"
+    },
+    "linkColor": {
+      "type": "string"
+    },
+    "letter-spacing": {
+      "type": "integer",
+      "minimum": -99,
+      "maximum": 99
+    },
+    "line-height": {
+      "type": "number",
+      "minimum": 0.5,
+      "maximum": 3,
+      "multipleOf": 0.00001
+    },
+    "direction": {
+      "enum": [
+        "ltr",
+        "rtl"
+      ]
+    },
+    "padding-top": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "padding-right": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "padding-bottom": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "padding-left": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "locked": {
+      "type": "boolean"
+    },
+    "customFields": {
+      "type": "object"
+    }
+  }
+}

--- a/partial-design-edits-concept/simple_row.schema.json
+++ b/partial-design-edits-concept/simple_row.schema.json
@@ -1,0 +1,114 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "simple_row.schema.json",
+    "title": "Simple Row",
+    "type": "object",
+    "required": [
+      "name",
+      "columns"
+    ],
+    "additionalProperties": false,
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "locked": {
+        "type": "boolean"
+      },
+      "colStackOnMobile": {
+        "type": "boolean"
+      },
+      "rowReverseColStackOnMobile": {
+        "type": "boolean"
+      },
+      "contentAreaBackgroundColor": {
+        "type": "string"
+      },
+      "background-color": {
+        "type": "string"
+      },
+      "background-image": {
+        "type": "string"
+      },
+      "background-position": {
+        "type": "string"
+      },
+      "background-repeat": {
+        "type": "string"
+      },
+      "customFields": {
+        "type": "object"
+      },
+      "border-radius": {
+        "$ref": "definitions.schema.json#/definitions/borderRadius"
+      },
+      "border-color": {
+        "type": "string"
+      },
+      "border-width": {
+        "$ref": "definitions.schema.json#/definitions/borderWidth"
+      },
+      "columnsBorderRadius": {
+        "$ref": "definitions.schema.json#/definitions/borderRadius"
+      },
+      "columnsSpacing": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 99
+      },
+      "vertical-align": {
+        "type": "string",
+        "enum": [
+          "top",
+          "middle",
+          "bottom"
+        ]
+      },
+      "display-condition": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "before": {
+            "type": "string"
+          },
+          "after": {
+            "type": "string"
+          }
+        }
+      },
+      "metadata": {
+        "type": "object"
+      },
+      "padding-top": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-right": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-bottom": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "padding-left": {
+        "$ref": "definitions.schema.json#/definitions/padding"
+      },
+      "columns": {
+        "type": "array",
+        "minItems": 1,
+        "maxItems": 12,
+        "items": {
+          "$ref": "simple_column.schema.json"
+        }
+      }
+    }
+  }

--- a/partial-design-edits-concept/simple_template.schema.json
+++ b/partial-design-edits-concept/simple_template.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "simple_template.schema.json",
+  "title": "Simple Template",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "template": {
+    "additionalProperties": false,
+      "type": "object",
+      "required": ["rows"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["email", "page", "popup"]
+        },
+        "rows": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "simple_row.schema.json"
+          }
+        },
+        "settings":{
+          "additionalProperties": false,
+          "type": "object",
+          "properties":{
+            "linkColor":{
+              "type": "string"
+            },
+            "background-color":{
+              "type": "string"
+            },
+            "contentAreaBackgroundColor":{
+              "type": "string"
+            },
+            "width": {
+              "type": "integer",
+              "minimum": 320,
+              "maximum": 1440
+            }
+          }
+        },
+        "metadata":{
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "lang": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "subject": {
+              "type": "string"
+            },
+            "preheader": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": ["template"]
+}

--- a/partial-design-edits-concept/simple_title.schema.json
+++ b/partial-design-edits-concept/simple_title.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "simple_title.schema.json",
+  "title": "Simple Title",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "enum": [
+        "title",
+        "heading"
+      ]
+    },
+    "underline": {
+      "type": "boolean"
+    },
+    "italic": {
+      "type": "boolean"
+    },
+    "bold": {
+      "type": "boolean"
+    },
+    "html": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    },
+    "align": {
+      "enum": [
+        "left",
+        "center",
+        "right",
+        "justify"
+      ]
+    },
+    "title": {
+      "enum": [
+        "h1",
+        "h2",
+        "h3"
+      ]
+    },
+    "size": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "color": {
+      "type": "string"
+    },
+    "linkColor": {
+      "type": "string"
+    },
+    "letter-spacing": {
+      "type": "integer",
+      "minimum": -99,
+      "maximum": 99
+    },
+    "line-height": {
+      "type": "number",
+      "minimum": 0.5,
+      "maximum": 3,
+      "multipleOf": 0.00001
+    },
+    "direction": {
+      "enum": [
+        "ltr",
+        "rtl"
+      ]
+    },
+    "padding-top": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "padding-right": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "padding-bottom": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "padding-left": {
+      "$ref": "definitions.schema.json#/definitions/padding"
+    },
+    "locked": {
+      "type": "boolean"
+    },
+    "customFields": {
+      "type": "object"
+    }
+  }
+}

--- a/partial-design-edits-concept/simple_unified.schema.json
+++ b/partial-design-edits-concept/simple_unified.schema.json
@@ -1,0 +1,871 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "simple_template.schema.json",
+  "definitions": {
+    "padding": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 60
+    },
+    "borderRadius": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 60
+    },
+    "borderWidth": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 30
+    },
+    "typeOfModules": {
+      "enum": [
+        "button",
+        "divider",
+        "heading",
+        "html",
+        "icons",
+        "image",
+        "list",
+        "menu",
+        "paragraph",
+        "title"
+      ]
+    }
+  },
+  "title": "Simple Template",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "template": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "rows"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "email",
+            "page",
+            "popup"
+          ]
+        },
+        "rows": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "title": "Simple Row",
+            "type": "object",
+            "required": [
+              "name",
+              "columns"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "locked": {
+                "type": "boolean"
+              },
+              "colStackOnMobile": {
+                "type": "boolean"
+              },
+              "rowReverseColStackOnMobile": {
+                "type": "boolean"
+              },
+              "contentAreaBackgroundColor": {
+                "type": "string"
+              },
+              "background-color": {
+                "type": "string"
+              },
+              "background-image": {
+                "type": "string"
+              },
+              "background-position": {
+                "type": "string"
+              },
+              "background-repeat": {
+                "type": "string"
+              },
+              "customFields": {
+                "type": "object"
+              },
+              "border-radius": {
+                "$ref": "#/definitions/borderRadius"
+              },
+              "border-color": {
+                "type": "string"
+              },
+              "border-width": {
+                "$ref": "#/definitions/borderWidth"
+              },
+              "columnsBorderRadius": {
+                "$ref": "#/definitions/borderRadius"
+              },
+              "columnsSpacing": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 99
+              },
+              "vertical-align": {
+                "type": "string",
+                "enum": [
+                  "top",
+                  "middle",
+                  "bottom"
+                ]
+              },
+              "display-condition": {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "before": {
+                    "type": "string"
+                  },
+                  "after": {
+                    "type": "string"
+                  }
+                }
+              },
+              "metadata": {
+                "type": "object"
+              },
+              "padding-top": {
+                "$ref": "#/definitions/padding"
+              },
+              "padding-right": {
+                "$ref": "#/definitions/padding"
+              },
+              "padding-bottom": {
+                "$ref": "#/definitions/padding"
+              },
+              "padding-left": {
+                "$ref": "#/definitions/padding"
+              },
+              "columns": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 12,
+                "items": {
+                  "title": "Simple Column",
+                  "type": "object",
+                  "required": [
+                    "weight",
+                    "modules"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "weight": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 12
+                    },
+                    "background-color": {
+                      "type": "string"
+                    },
+                    "padding-top": {
+                      "$ref": "#/definitions/padding"
+                    },
+                    "padding-right": {
+                      "$ref": "#/definitions/padding"
+                    },
+                    "padding-bottom": {
+                      "$ref": "#/definitions/padding"
+                    },
+                    "padding-left": {
+                      "$ref": "#/definitions/padding"
+                    },
+                    "border-color": {
+                      "type": "string"
+                    },
+                    "border-width": {
+                      "$ref": "#/definitions/borderWidth"
+                    },
+                    "modules": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "type"
+                        ],
+                        "discriminator": {
+                          "propertyName": "type"
+                        },
+                        "properties": {
+                          "type": {
+                            "$ref": "#/definitions/typeOfModules"
+                          }
+                        },
+                        "oneOf": [
+                          {
+                            "title": "Simple Button",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "type": {
+                                "const": "button"
+                              },
+                              "label": {
+                                "type": "string",
+                                "format": "noAnchorTags"
+                              },
+                              "text": {
+                                "type": "string",
+                                "format": "noAnchorTags"
+                              },
+                              "align": {
+                                "enum": [
+                                  "left",
+                                  "center",
+                                  "right"
+                                ]
+                              },
+                              "href": {
+                                "type": "string"
+                              },
+                              "target": {
+                                "enum": [
+                                  "_blank",
+                                  "_self",
+                                  "_top"
+                                ]
+                              },
+                              "size": {
+                                "type": "integer",
+                                "minimum": 1
+                              },
+                              "color": {
+                                "type": "string"
+                              },
+                              "background-color": {
+                                "type": "string"
+                              },
+                              "padding-top": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-right": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-bottom": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-left": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "contentPaddingTop": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "contentPaddingRight": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "contentPaddingLeft": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "contentPaddingBottom": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "hoverBackgroundColor": {
+                                "type": "string"
+                              },
+                              "hoverColor": {
+                                "type": "string"
+                              },
+                              "hoverBorderColor": {
+                                "type": "string"
+                              },
+                              "hoverBorderWidth": {
+                                "$ref": "#/definitions/borderWidth"
+                              },
+                              "locked": {
+                                "type": "boolean"
+                              },
+                              "border-radius": {
+                                "$ref": "#/definitions/borderRadius"
+                              },
+                              "border-color": {
+                                "type": "string"
+                              },
+                              "border-width": {
+                                "$ref": "#/definitions/borderWidth"
+                              },
+                              "customFields": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          {
+                            "title": "Simple Divider",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "type": {
+                                "const": "divider"
+                              },
+                              "color": {
+                                "type": "string"
+                              },
+                              "height": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 30
+                              },
+                              "width": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 100
+                              },
+                              "padding-top": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-right": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-bottom": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-left": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "locked": {
+                                "type": "boolean"
+                              },
+                              "customFields": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          {
+                            "title": "Simple Html",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "type": {
+                                "const": "html"
+                              },
+                              "html": {
+                                "type": "string"
+                              },
+                              "customFields": {
+                                "type": "object"
+                              },
+                              "locked": {
+                                "type": "boolean"
+                              }
+                            }
+                          },
+                          {
+                            "title": "Simple Icons",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "type": {
+                                "const": "icons"
+                              },
+                              "icons": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "image",
+                                    "textPosition",
+                                    "width",
+                                    "height"
+                                  ],
+                                  "properties": {
+                                    "alt": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "image": {
+                                      "type": "string",
+                                      "format": "urlOrMergeTags"
+                                    },
+                                    "href": {
+                                      "type": "string",
+                                      "format": "urlOrMergeTagsOrEmpty"
+                                    },
+                                    "height": {
+                                      "type": "string"
+                                    },
+                                    "width": {
+                                      "type": "string"
+                                    },
+                                    "target": {
+                                      "enum": [
+                                        "_blank",
+                                        "_self",
+                                        "_top"
+                                      ]
+                                    },
+                                    "textPosition": {
+                                      "enum": [
+                                        "left",
+                                        "right",
+                                        "top",
+                                        "bottom"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "padding-top": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-right": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-bottom": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-left": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "locked": {
+                                "type": "boolean"
+                              },
+                              "customFields": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          {
+                            "title": "Simple Image",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "type": {
+                                "const": "image"
+                              },
+                              "alt": {
+                                "type": "string"
+                              },
+                              "href": {
+                                "type": "string"
+                              },
+                              "src": {
+                                "type": "string",
+                                "format": "urlOrMergeTags"
+                              },
+                              "dynamicSrc": {
+                                "type": "string"
+                              },
+                              "target": {
+                                "enum": [
+                                  "_blank",
+                                  "_self",
+                                  "_top"
+                                ]
+                              },
+                              "padding-top": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-right": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-bottom": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-left": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "locked": {
+                                "type": "boolean"
+                              },
+                              "customFields": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          {
+                            "title": "Simple List",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "type": {
+                                "const": "list"
+                              },
+                              "underline": {
+                                "type": "boolean"
+                              },
+                              "italic": {
+                                "type": "boolean"
+                              },
+                              "bold": {
+                                "type": "boolean"
+                              },
+                              "html": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "align": {
+                                "enum": [
+                                  "left",
+                                  "center",
+                                  "right"
+                                ]
+                              },
+                              "tag": {
+                                "enum": [
+                                  "ol",
+                                  "ul"
+                                ]
+                              },
+                              "size": {
+                                "type": "integer",
+                                "minimum": 1
+                              },
+                              "color": {
+                                "type": "string"
+                              },
+                              "linkColor": {
+                                "type": "string"
+                              },
+                              "letter-spacing": {
+                                "type": "integer",
+                                "minimum": -99,
+                                "maximum": 99
+                              },
+                              "line-height": {
+                                "type": "number",
+                                "minimum": 0.5,
+                                "maximum": 3,
+                                "multipleOf": 0.00001
+                              },
+                              "padding-top": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-right": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-bottom": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-left": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "locked": {
+                                "type": "boolean"
+                              },
+                              "direction": {
+                                "enum": [
+                                  "ltr",
+                                  "rtl"
+                                ]
+                              },
+                              "customFields": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          {
+                            "title": "Simple Menu",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "type": {
+                                "const": "menu"
+                              },
+                              "items": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "type": {
+                                      "const": "menu-item"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "link": {
+                                      "type": "object",
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "href": {
+                                          "type": "string",
+                                          "format": "urlOrMergeTagsOrEmpty"
+                                        },
+                                        "target": {
+                                          "enum": [
+                                            "_blank",
+                                            "_self",
+                                            "_top"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "padding-top": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-right": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-bottom": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-left": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "locked": {
+                                "type": "boolean"
+                              },
+                              "customFields": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          {
+                            "title": "Simple Paragraph",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "type": {
+                                "const": "paragraph"
+                              },
+                              "underline": {
+                                "type": "boolean"
+                              },
+                              "italic": {
+                                "type": "boolean"
+                              },
+                              "bold": {
+                                "type": "boolean"
+                              },
+                              "html": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "align": {
+                                "enum": [
+                                  "left",
+                                  "center",
+                                  "right",
+                                  "justify"
+                                ]
+                              },
+                              "size": {
+                                "type": "integer",
+                                "minimum": 1
+                              },
+                              "color": {
+                                "type": "string"
+                              },
+                              "linkColor": {
+                                "type": "string"
+                              },
+                              "letter-spacing": {
+                                "type": "integer",
+                                "minimum": -99,
+                                "maximum": 99
+                              },
+                              "line-height": {
+                                "type": "number",
+                                "minimum": 0.5,
+                                "maximum": 3,
+                                "multipleOf": 0.00001
+                              },
+                              "direction": {
+                                "enum": [
+                                  "ltr",
+                                  "rtl"
+                                ]
+                              },
+                              "padding-top": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-right": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-bottom": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-left": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "locked": {
+                                "type": "boolean"
+                              },
+                              "customFields": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          {
+                            "title": "Simple Title",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "type": {
+                                "enum": [
+                                  "title",
+                                  "heading"
+                                ]
+                              },
+                              "underline": {
+                                "type": "boolean"
+                              },
+                              "italic": {
+                                "type": "boolean"
+                              },
+                              "bold": {
+                                "type": "boolean"
+                              },
+                              "html": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "align": {
+                                "enum": [
+                                  "left",
+                                  "center",
+                                  "right",
+                                  "justify"
+                                ]
+                              },
+                              "title": {
+                                "enum": [
+                                  "h1",
+                                  "h2",
+                                  "h3"
+                                ]
+                              },
+                              "size": {
+                                "type": "integer",
+                                "minimum": 1
+                              },
+                              "color": {
+                                "type": "string"
+                              },
+                              "linkColor": {
+                                "type": "string"
+                              },
+                              "letter-spacing": {
+                                "type": "integer",
+                                "minimum": -99,
+                                "maximum": 99
+                              },
+                              "line-height": {
+                                "type": "number",
+                                "minimum": 0.5,
+                                "maximum": 3,
+                                "multipleOf": 0.00001
+                              },
+                              "direction": {
+                                "enum": [
+                                  "ltr",
+                                  "rtl"
+                                ]
+                              },
+                              "padding-top": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-right": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-bottom": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "padding-left": {
+                                "$ref": "#/definitions/padding"
+                              },
+                              "locked": {
+                                "type": "boolean"
+                              },
+                              "customFields": {
+                                "type": "object"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "customFields": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "settings": {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "linkColor": {
+              "type": "string"
+            },
+            "background-color": {
+              "type": "string"
+            },
+            "contentAreaBackgroundColor": {
+              "type": "string"
+            },
+            "width": {
+              "type": "integer",
+              "minimum": 320,
+              "maximum": 1440
+            }
+          }
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "lang": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "subject": {
+              "type": "string"
+            },
+            "preheader": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "template"
+  ]
+}

--- a/partial-design-edits-concept/start.sh
+++ b/partial-design-edits-concept/start.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+echo "🚀 Starting Beefree SDK Partial Design Edits Demo"
+echo "================================================="
+
+# Check if Node.js is installed
+if ! command -v node &> /dev/null; then
+    echo "❌ Node.js is not installed. Please install Node.js first."
+    exit 1
+fi
+
+# Check if npm is installed
+if ! command -v npm &> /dev/null; then
+    echo "❌ npm is not installed. Please install npm first."
+    exit 1
+fi
+
+echo "✅ Node.js and npm are installed"
+
+# Check if node_modules exists, if not install dependencies
+if [ ! -d "node_modules" ]; then
+    echo "📦 Installing dependencies..."
+    npm install
+    if [ $? -ne 0 ]; then
+        echo "❌ Failed to install dependencies"
+        exit 1
+    fi
+    echo "✅ Dependencies installed successfully"
+else
+    echo "✅ Dependencies already installed"
+fi
+
+# Check if credentials.js exists
+if [ ! -f "credentials.js" ]; then
+    echo "❌ credentials.js file not found!"
+    echo "Please create a credentials.js file with your API keys:"
+    echo ""
+    echo "module.exports = {"
+    echo "    anthropic_api_key: 'your_anthropic_key_here',"
+    echo "    beefree_api_key: 'your_beefree_key_here'"
+    echo "};"
+    echo ""
+    echo "You can copy credentials.example.js to credentials.js and update the values."
+    exit 1
+fi
+
+echo "✅ credentials.js file found"
+
+echo ""
+echo "🌐 Starting the proxy server..."
+echo "The demo will be available at: http://localhost:3000"
+echo ""
+echo "📝 How to use:"
+echo "1. Open http://localhost:3000 in your browser"
+echo "2. Click 'Upload Template' to load an existing JSON template"
+echo "3. Click 'Save' in the Beefree editor to enable chat functionality"
+echo "4. Use the chat to describe specific changes to your design"
+echo "5. AI will apply your changes and update the design automatically"
+echo ""
+echo "💡 Example chat prompts:"
+echo "- 'Rewrite the paragraph in row 3 column 2'"
+echo "- 'Add another row promoting our latest blog posts'"
+echo "- 'Change the color of the main heading to blue'"
+echo "- 'Add a button after the first paragraph'"
+echo ""
+echo "Press Ctrl+C to stop the server"
+echo ""
+
+# Start the proxy server
+node proxy-server.js 

--- a/partial-design-edits-concept/styles.css
+++ b/partial-design-edits-concept/styles.css
@@ -1,0 +1,519 @@
+/*
+  "--cs" for custom css override classes
+
+  --- Generals ---
+  - Custom font url | https://fast.fonts.net/cssapi/12006fbc-93aa-46b4-b1a2-436f9d660c2c.css
+  - Custom font family (with font stack - i.e. 'Source Sans Pro', sans-serif) | "Frutiger Next W01",Helvetica,Arial,sans-serif
+  - Custom font size | 12px
+  - Widget bar border color | #c7c7c7
+  - Widget bar & active tab background color | #F9F9F9
+  - Show tab icons [BOOLEAN] - if (true) "inline-block" else "none" | True
+  ***
+  - Custom brand primary color | #4cb9ea
+  - Custom brand primary color - Light | #73c5e9
+  - Custom brand primary color - Dark | #78abc1
+  - Custom brand secondary color | #898989
+
+  --- Stage ---
+  - Stage label text color
+
+  --- Tabs ---
+  - Active tab text & icon color | #516167
+  - Not Active tabs background color | #d6d9dc
+  - Not Active tabs text & icon color | #93989a
+  - Not Active tabs text & icon color :hover | #505659
+
+  --- Tiles ---
+  - Panel default (Widget, Row and Social panels) background color | #FFFFFF
+  - Panel default border color
+  - Panel default border radius value | 4px
+  - Panel :hover box shadow value (i.e. "0 6px 10px rgba(0, 0, 0, 0.1)") | 0 6px 10px rgba(0,0,0,.35)
+
+  --- Properties panel ---
+  - Properties panel title background  | #FFF
+  - Properties panel text & icons color | #505659
+  - Properties panel title border | #E1E4E7
+
+  --- Widgets ---
+  - Widgets section title background | #eaeaea
+  - Widgets section title color | #505659
+  - Widget bottom border color (widget divider) | #e1e4e7
+  - Widget label color | #8f9699
+  *** Inputs ***
+  - Inputs border color | #cccccc
+  - Inputs background color | #ffffff
+  - Inputs text color | #505659
+  *** Toggle ***
+  - Background toggle -> off | #ffffff
+  - Background Switch -> off | #cccccc
+  - Background Switch -> on | #ffffff
+  *** Icons
+  - Color icon base |
+  - Color icon base - Light |
+  - Color icon base - Dark |
+
+  --- Customize Widgets - Icon Organizer widget ---
+  - Icon organizer panel background color | #ffffff
+  - Icon organizer icon thumbnail background | #eeeeee
+  - Icon organizer border color | #dddddd
+  - Icon organizer delete cta color | #bb3636
+  - Icon manager Pop background color | rgba(80,86,89,.95)
+  - Icon manager Pop tabs border-color | #7b7b7b
+  - Icon manager Pop tabs color | #a0a0a0
+  - Icon manager Pop tabs active color | #ffffff
+  - Icon manager Pop icons color | #ffffff
+*/
+
+@import url(https://fonts.googleapis.com/css?family=Roboto);
+
+html,
+body.bee--cs {
+  font-size: 13px;
+}
+
+html,
+body.bee--cs,
+body.bee--cs .h1,
+body.bee--cs .h2,
+body.bee--cs .h3,
+body.bee--cs .h4,
+body.bee--cs .h5,
+body.bee--cs .h6,
+body.bee--cs .tooltip,
+body.bee--cs h1,
+body.bee--cs h2,
+body.bee--cs h3,
+body.bee--cs h4,
+body.bee--cs h5,
+body.bee--cs h6,
+body.bee--cs .tgl-title {
+  font-family: "Roboto", sans-serif;
+}
+
+.widget-bar.widget-bar--cs,
+.widget-bar.widget-bar--cs .tabset__tab--cs a,
+.widget-bar.widget-bar--cs .tabset__tab--cs.active a,
+.widget-bar.widget-bar--cs .tabset__tab--cs.active a:hover {
+  border-left-color: #202020;
+}
+
+.widget-bar.widget-bar--cs .tabset__tab--cs a {
+  background: #dcdcdc;
+  border-bottom-color: #202020;
+  color: #707070;
+}
+
+.widget-bar.widget-bar--cs .tabset__tab--cs a:hover {
+  background: #dcdcdc;
+  color: #606060;
+}
+
+.widget-bar.widget-bar--cs .tabset__tab--cs.active a,
+.widget-bar.widget-bar--cs .tabset__tab--cs.active a:hover {
+  border-bottom-color: #202020;
+  color: #dcdcdc;
+}
+
+.widget-bar.widget-bar--cs .tabset__tab--cs:first-child a,
+.widget-bar.widget-bar--cs .tabset__tab--cs:first-child a:hover {
+  border-left: 0;
+}
+
+.widget-bar.widget-bar--cs .tabset__tab--cs.active a,
+.widget-bar.widget-bar--cs .tabset__tab--cs.active a:hover,
+.widget-bar.widget-bar--cs .widget-bar__scroll-container--cs,
+.widget-bar.widget-bar--cs .properties-panel__scroll-container--cs {
+  background-color: #202020;
+}
+
+.widget-bar.widget-bar--cs .tabset__tab--cs a:before {
+  display: inline-block;
+}
+
+body.bee--cs .dragging.module,
+body.bee--cs .dragging.row,
+body.bee--cs .dragging.new-row,
+body.bee--cs .dragging.new-module {
+  background-color: #303030;
+}
+
+.widget-bar.widget-bar--cs .panel--default.panel--cs {
+  border-color: #505050;
+}
+
+.widget-bar.widget-bar--cs .radio-button--cs .radio-button__radio,
+.widget-bar.widget-bar--cs .panel--default.panel--cs {
+  background-color: #303030;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+}
+
+.widget-bar.widget-bar--cs .radio-button--cs .radio-button__radio {
+  border-color: #303030;
+}
+
+.widget-bar.widget-bar--cs .panel--default.panel--cs:hover {
+  border: 1px solid #303030;
+  -webkit-box-shadow: 0 6px 10px rgba(0,0,0,.15);
+  box-shadow: 0 6px 10px rgba(0,0,0,.15);
+}
+
+.widget-bar.widget-bar--cs .widgets-section .widgets-section__title--cs {
+  background-color: #303030;
+  color: #f5f5f5;
+}
+
+.widget-bar.widget-bar--cs .panel--default.panel--cs .body__title--cs,
+.widget-bar.widget-bar--cs .widgets-section .widgets-section__title--cs {
+  color: #f5f5f5;
+}
+
+.widget-bar.widget-bar--cs .hr--cs,
+.widget-bar.widget-bar--cs .icon-organizer__panel--cs .panel__content.first-block {
+  border-top: 1px solid #303030;
+}
+
+.widget-bar.widget-bar--cs .widgets-section .widgets-section__columns-container .nav-tabs li.active a,
+.widget-bar.widget-bar--cs .widgets-section .widgets-section__columns-container .nav-tabs li.active a:hover {
+  border-right: 1px solid #303030;
+}
+
+.widget-bar.widget-bar--cs .widgets-section .widgets-section__columns-container .nav-tabs li a {
+  color: #909090;
+  opacity: .6;
+}
+
+.widget-bar.widget-bar--cs .widgets-section .widgets-section__columns-container .nav-tabs li.active a {
+  opacity: 1;
+}
+
+.widget-bar.widget-bar--cs .widgets-section .widgets-section__columns-container .nav-tabs,
+.widget-bar.widget-bar--cs .widgets-section .widgets-section__columns-container .tab-content .tab-pane > div,
+.widget-bar.widget-bar--cs .widgets-section .widgets-section__wrapper > div {
+  border-bottom: 1px solid #303030;
+}
+
+  .widget-bar.widget-bar--cs .widgets-section .widgets-section__wrapper > div:last-child {
+    border-bottom: 0;
+  }
+
+.widget-bar.widget-bar--cs .widget__box .box__label--cs,
+.widget-bar.widget-bar--cs .tgl-container--cs .tgl-title,
+.widget-bar.widget-bar--cs .tgl-container--cs .tgl-label,
+.widget-bar.widget-bar--cs .widget__label--cs,
+.widget-bar.widget-bar--cs .icon-organizer__panel--cs .panel__title {
+  color: #909090;
+}
+
+.widget-bar.widget-bar--cs .properties-panel__title--cs h4 {
+  background: #ffffff;
+  border-top-color: #e1e4e7;
+  border-bottom-color: #e1e4e7;
+}
+
+.widget-bar.widget-bar--cs .properties-panel__title--cs h4,
+.widget-bar.widget-bar--cs .properties-panel__title--cs > .close-panel,
+.widget-bar.widget-bar--cs .properties-panel__title--cs > .icon-delete,
+.widget-bar.widget-bar--cs .properties-panel__title--cs > .icon-duplicate {
+  color: #606060;
+  border-left-color: #e1e4e7;
+}
+
+.widget-bar.widget-bar--cs .properties-panel__title--cs > .close-panel:hover,
+.widget-bar.widget-bar--cs .properties-panel__title--cs > .icon-duplicate:hover {
+  background: #606060;
+  color: #ffffff;
+}
+
+.widget-bar.widget-bar--cs .dropdown-custom--cs .arrows,
+.widget-bar.widget-bar--cs .dropdown-custom--cs .dropdown-toggle,
+.widget-bar.widget-bar--cs .number-selector--cs .btn,
+.widget-bar.widget-bar--cs .width-style-color-container--cs .number-selector--cs .btn,
+.widget-bar.widget-bar--cs .wrapper-color-selector--cs,
+.widget-bar.widget-bar--cs .wrapper-color-selector--cs input[type="text"],
+.widget-bar.widget-bar--cs .href-container--cs input[type="text"],
+.widget-bar.widget-bar--cs .background-image-container--cs input[type="text"],
+.widget-bar.widget-bar--cs .image-selector-container--cs input[type="text"],
+.widget-bar.widget-bar--cs .alternate-txt--cs input[type="text"],
+.widget-bar.widget-bar--cs .href-container--cs .input-group-addon,
+.widget-bar.widget-bar--cs .background-image-container--cs .input-group-addon,
+.widget-bar.widget-bar--cs .icon-organizer__panel--cs input[type="text"],
+.widget-bar.widget-bar--cs .icon-organizer__panel--cs .input-group-addon,
+.widget-bar.widget-bar--cs .icon-manager__add-icon--cs {
+  color: #c0c0c0;
+}
+
+.widget-bar.widget-bar--cs .dropdown-custom--cs .dropdown-toggle,
+.widget-bar.widget-bar--cs .number-selector--cs .btn,
+.widget-bar.widget-bar--cs .width-style-color-container--cs .number-selector--cs .btn-group,
+.widget-bar.widget-bar--cs .width-style-color-container--cs .number-selector--cs .btn,
+.widget-bar.widget-bar--cs .wrapper-color-selector--cs,
+.widget-bar.widget-bar--cs .wrapper-color-selector--cs div,
+.widget-bar.widget-bar--cs .tgl-container--cs .tgl_body,
+.widget-bar.widget-bar--cs .href-container--cs input[type="text"],
+.widget-bar.widget-bar--cs .background-image-container--cs input[type="text"],
+.widget-bar.widget-bar--cs .image-selector-container--cs input[type="text"],
+.widget-bar.widget-bar--cs .alternate-txt--cs input[type="text"],
+.widget-bar.widget-bar--cs .href-container--cs .input-group-addon,
+.widget-bar.widget-bar--cs .background-image-container--cs .input-group-addon,
+.widget-bar.widget-bar--cs .icon-organizer__panel--cs input[type="text"],
+.widget-bar.widget-bar--cs .icon-organizer__panel--cs .input-group-addon {
+  border-color: #202020;
+}
+
+.widget-bar.widget-bar--cs .dropdown-custom--cs .dropdown-toggle,
+.widget-bar.widget-bar--cs .number-selector--cs .btn,
+.widget-bar.widget-bar--cs .width-style-color-container--cs .number-selector--cs .btn,
+.widget-bar.widget-bar--cs .wrapper-color-selector--cs,
+.widget-bar.widget-bar--cs .wrapper-color-selector--cs input[type="text"],
+.widget-bar.widget-bar--cs .href-container--cs input[type="text"],
+.widget-bar.widget-bar--cs .background-image-container--cs input[type="text"],
+.widget-bar.widget-bar--cs .image-selector-container--cs input[type="text"],
+.widget-bar.widget-bar--cs .alternate-txt--cs input[type="text"],
+.widget-bar.widget-bar--cs .href-container--cs .input-group-addon,
+.widget-bar.widget-bar--cs .background-image-container--cs .input-group-addon,
+.widget-bar.widget-bar--cs .icon-organizer__panel--cs input[type="text"],
+.widget-bar.widget-bar--cs .icon-organizer__panel--cs .input-group-addon,
+.widget-bar.widget-bar--cs .icon-manager__add-icon--cs {
+  background-color: #696969;
+}
+
+.widget-bar.widget-bar--cs .icon-manager__add-icon--cs:hover {
+  color: #696969;
+  background-color: #c0c0c0;
+}
+
+.widget-bar.widget-bar--cs .href-container--cs a {
+  border-right: 1px solid #202020;
+}
+
+.widget-bar.widget-bar--cs .icon-organizer__panel--cs {
+  background: #202020;
+  border-color: #202020;
+}
+
+.widget-bar.widget-bar--cs .icon-type-selector .dropdown-toggle--social .dropdown-toggle__set,
+.widget-bar.widget-bar--cs .icon-organizer__panel--cs .panel__icon-preview-wrapper--cs {
+  background: #505050;
+}
+
+.widget-bar.widget-bar--cs .icon-organizer__panel--cs .icon-remove {
+  color: #c0c0c0;
+}
+
+.widget-bar.widget-bar--cs .icons-manager__pop--cs {
+  background: rgba(192,192,192,1);
+}
+
+.widget-bar.widget-bar--cs .icons-manager__pop--cs:after {
+  border-top-color: rgba(192,192,192,1);
+}
+
+.widget-bar.widget-bar--cs .icons-manager__pop--cs .nav-tabs > li > a {
+  color: rgba(255,255,255,0.6);
+  border-left-color: rgba(255,255,255,0.2);
+  border-bottom-color: rgba(255,255,255,0.2);
+}
+
+.widget-bar.widget-bar--cs .icons-manager__pop--cs .nav-tabs > li.active > a {
+  color: #f8f8f8;
+}
+
+.widget-bar.widget-bar--cs .icons-manager__pop--cs .tab-content .tab-pane > div > a {
+  color: #f8f8f8;
+}
+
+.widget-bar.widget-bar--cs .tgl-container--cs .tgl .tgl_bgd-negative {
+  background-color: #505050;
+}
+
+.widget-bar.widget-bar--cs .tgl-container--cs .tgl .tgl_switch {
+  background-color: #bebebe;
+}
+
+.widget-bar.widget-bar--cs .tgl-container--cs .tgl > :not(:checked) ~ .tgl_body > .tgl_switch {
+  background-color: #e0e0e0;
+}
+
+body.bee--cs .dragging.module svg path,
+body.bee--cs .dragging.row svg .icon--color-base,
+body.bee--cs .dragging.new-row svg .icon--color-base,
+body.bee--cs .dragging.new-module svg path,
+.widget-bar.widget-bar--cs svg path,
+.widget-bar.widget-bar--cs svg rect,
+.widget-bar.widget-bar--cs svg .icon--color-base {
+  fill: #909090 !important;
+}
+
+body.bee--cs .dragging.row svg .icon--color-light,
+body.bee--cs .dragging.new-row svg .icon--color-light,
+.widget-bar.widget-bar--cs svg .icon--color-light {
+  fill: #404040 !important;
+}
+
+body.bee--cs .dragging.row svg .icon--color-dark,
+body.bee--cs .dragging.new-row svg .icon--color-dark,
+.widget-bar.widget-bar--cs svg .icon--color-dark {
+  fill: rgba(32,32,32,1) !important;
+}
+
+  /* BRAND PRIMARY
+ --------------------------------------- */
+ body.bee--cs .selected.module-box:before,
+body.bee--cs .selected.row-container .row-selector:before,
+body.bee--cs .selected.module-box > .icon-move,
+body.bee--cs .selected.row-container > .icon-move,
+body.bee--cs .row-container > .edit-icons,
+body.bee--cs .module-box > .edit-icons,
+body.bee--cs .btn-primary,
+body.bee--cs .btn-primary:hover,
+body.bee--cs .btn-primary:active,
+body.bee--cs .btn-primary:focus,
+.widget-bar.widget-bar--cs .tgl-container--cs .tgl_bgd,
+.widget-bar.widget-bar--cs .padding-container .square,
+.widget-bar.widget-bar--cs .hideon-container .tgl-label.active,
+.lock-container--cs.locked {
+  background-color: #c0c0c0;
+}
+
+.widget-bar.widget-bar--cs .widgets-section .widgets-section__columns-container .nav-tabs li.active a,
+.widget-bar.widget-bar--cs .widgets-section .widgets-section__columns-container .nav-tabs li.active a:hover {
+  border-bottom-color: #c0c0c0;
+}
+
+.widget-bar.widget-bar--cs .href-container--cs a {
+  color: #c0c0c0;
+}
+
+body.bee--cs .module-box:after,
+body.bee--cs .row-container .row-selector:after {
+  outline: 2px solid #696969;
+  background-color: rgba(105, 105, 105, 0.15);;
+  opacity: 0;
+}
+
+body.bee--cs .structure-shows .row-container .row-selector:after {
+  outline: #ccc dashed 1px;
+  opacity: 1;
+  background: 0 0;
+}
+
+body.bee--cs .structure-shows .row-container .row-selector:hover::after {
+  outline: 2px solid #696969;
+	background-color: rgba(105, 105, 105, 0.15);;
+}
+
+body.bee--cs .page-stage table .row-container:not(.no-hover):hover .row-selector,
+body.bee--cs .page-stage table .row-container:not(.no-hover):hover .row-selector:after {
+  opacity: 1;
+  z-index: 1;
+}
+
+body.bee--cs .module-box:before,
+body.bee--cs .row-container .row-selector:before,
+body.bee--cs .module-box > .icon-move,
+body.bee--cs .row-container > .icon-move {
+  background-color:#696969;
+}
+
+body.bee--cs .page-stage .selected.module-box:after,
+body.bee--cs .page-stage .selected.module-box .row-selector:after,
+body.bee--cs .page-stage .selected.row-container:after,
+body.bee--cs .page-stage .selected.row-container .row-selector:after {
+  outline: 2px solid #c0c0c0;
+  background: 0 0;
+  opacity: 1;
+}
+
+body.bee--cs .module-box > .edit-icons li,
+body.bee--cs .row-container > .edit-icons li {
+  border-right-color: #a9a9a9;
+}
+
+body.bee--cs .btn-primary,
+body.bee--cs .btn-primary:hover,
+body.bee--cs .btn-primary:active,
+body.bee--cs .btn-primary:focus {
+  border-color: #c0c0c0;
+}
+
+.lock-container--cs,
+body.bee--cs .btn-default {
+  background: #808080;
+}
+
+body.bee--cs .btn-default {
+  border-color: #808080;
+}
+
+body.bee--cs .row-container > .edit-icons li:hover,
+body.bee--cs .module-box > .edit-icons li:hover {
+  background-color: #696969;
+}
+
+body.bee--cs .comp-tree-placeholder:after {
+  outline: 3px solid #c0c0c0;
+}
+
+body.bee--cs .comp-tree-placeholder:before {
+  background-color: #c0c0c0;
+  color: #ffffff;
+}
+
+body.bee--cs .module-box:before,
+body.bee--cs .row-container .row-selector:before,
+body.bee--cs .module-box > .icon-move,
+body.bee--cs .row-container > .icon-move,
+body.bee--cs .row-container > .edit-icons li,
+body.bee--cs .module-box > .edit-icons li {
+  color: StageLabelTextColor;
+}
+
+body.bee--cs .module-empty {
+  outline: 1px dashed #c0c0c0;
+  background: #a9a9a9;
+}
+
+body.bee--cs .module-empty:before {
+  color: #c0c0c0;
+}
+
+/* Range Selector */
+body.bee--cs .range-selector input[type=range]::-webkit-slider-runnable-track {
+  background: #c0c0c0;
+}
+
+body.bee--cs .range-selector input[type=range]:focus::-webkit-slider-runnable-track {
+  background: #c0c0c0;
+}
+
+body.bee--cs .range-selector input[type=range]::-moz-range-track {
+  background: #c0c0c0;
+}
+
+body.bee--cs .range-selector input[type=range]::-ms-track {
+  background: transparent;
+}
+
+body.bee--cs .range-selector input[type=range]::-ms-fill-lower {
+  background: #c0c0c0;
+}
+
+body.bee--cs .range-selector input[type=range]:focus::-ms-fill-lower {
+  background: #c0c0c0;
+}
+
+body.bee--cs .range-selector input[type=range]::-ms-fill-upper {
+  background: #c0c0c0;
+}
+
+body.bee--cs .range-selector input[type=range]:focus::-ms-fill-upper {
+  background: #c0c0c0;
+}
+
+.undo-redo--cs .undo-redo__history .history__step.history__step--active:before,
+.undo-redo--cs .undo-redo__history .history__step.history__step--focused:after,
+.undo-redo--cs .undo-redo__history .history__step.history__step--focused:before,
+.undo-redo--cs .undo-redo__history .history__step:hover:before {
+  background: #c0c0c0;
+}

--- a/simple-schema-concept/beefree-cookbook-single-email.md
+++ b/simple-schema-concept/beefree-cookbook-single-email.md
@@ -1,30 +1,57 @@
-# Create AI-generated Emails in Beefree SDK with Anthropic's Claude AI and Simple Schema
+---
+description: >-
+  Create AI-generated Emails in Beefree SDK with Anthropic's Claude AI and
+  Simple Schema
+---
 
-This recipe demonstrates how to build an AI-powered email creation system that generates email templates using Anthropic's Claude API and converts them to full Beefree SDK templates using the Simple Schema format.
+# Create AI-generated Emails in Beefree SDK with Claude AI
 
 ## Overview
 
+This recipe explains how to build an AI-powered email creation system that generates email templates using [Anthropic's Messages API](https://docs.anthropic.com/en/api/messages), along with the [Claude Sonnet 4 model](https://docs.anthropic.com/en/docs/about-claude/models/overview#model-names), and converts them to full Beefree SDK templates using both [Simple Schema](../../data-structures/simple-schema) and the [Content Services API](../../apis/content-services-api).
+
 This recipe covers:
-1. **Simple Schema**: Understanding the template structure and unified schema
-2. **Anthropic API Integration**: Structuring API calls and handling responses
-3. **Frontend Integration**: Capturing user input and sending to AI
-4. **Response Parsing**: Extracting and validating JSON from AI responses
-5. **Beefree SDK Integration**: Converting simple templates to full templates and loading in the builder
+
+1. **Simple Schema**: Understanding the [template structure](../../data-structures/simple-schema/template-schema) and [unified schema](../../../data-structures/simple-schema#simple-unified-schema).
+2. **Anthropic API Integration**: [Structuring API calls](https://docs.anthropic.com/en/api/messages) and handling responses.
+3. **Frontend Integration**: Capturing end user email descriptions and sending it to Anthropic inside a detailed prompt.
+4. **Response Parsing**: Extracting and validating JSON from Anthropic's responses.
+5. **Beefree SDK Integration**: Converting [simple templates to full templates](../../../apis/content-services-api/convert#simple-to-full-json) and [loading them in the builder](../../getting-started/readme/installation/methods-and-events).
+
+Reference the complete code for this project in the [simple-schema-concept](broken-reference) folder inside the [Simple Schema GitHub repository](https://github.com/BeefreeSDK/beefree-sdk-simple-schema/tree/main).
+
+{% embed url="https://github.com/BeefreeSDK/beefree-sdk-simple-schema/tree/main/simple-schema-concept" %}
 
 ## Prerequisites
 
-- Node.js (v14 or higher)
-- Anthropic API key
-- Beefree SDK credentials
-- Basic knowledge of JavaScript and Express.js
+* [Node.js](broken-reference)
+* [Anthropic API key](https://docs.anthropic.com/en/api/overview)
+* [Beefree SDK credentials](../../../getting-started/readme/create-an-application#obtain-your-client-id-and-client-secret)
+* Understanding of Beefree SDK's [Simple Schema](../../data-structures/simple-schema)
+* Knowledge of Beefree SDK's [Content Services API](../../apis/content-services-api) and [`/simple-to-full-json endpoint`](../../../apis/content-services-api/convert#simple-to-full-json)&#x20;
 
-## Core Concepts
+## Core Concepts and Steps
 
-### 1. Simple Schema Structure
+This section details all of the core concepts required to integrate AI-generated emails within Beefree SDK. It includes descriptions of each concept, sample code, and a the complete implementation at the end, along with customization tips.
 
-The Simple Schema is a simplified JSON format that makes it easy to generate email templates programmatically. It uses a hierarchical structure with templates, rows, columns, and modules.
+As a reminder, the complete code for this recipe is available for reference in [GitHub](broken-reference).
 
-#### Template Structure
+The following video shows the final result, and how the code for this recipe looks when you run it locally on your machine. &#x20;
+
+{% embed url="https://screen.studio/share/G7GQSZet" %}
+
+&#x20;The following diagram shows how these core concepts relate to one another to create the experience shown in the video above.
+
+<figure><img src="https://806400411-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2F8c7XIQHfAtM23Dp3ozIC%2Fuploads%2FUM25XtPneeIwKIlBMeol%2Fimage.png?alt=media&#x26;token=ba9b41e4-be22-4c18-b79c-7d98cf232ce4" alt=""><figcaption></figcaption></figure>
+
+## 1. Simple Schema Structure
+
+[Simple Schema](../../data-structures/simple-schema) is a simplified JSON format that makes it easy to generate email templates programmatically. It uses a hierarchical structure with templates, rows, columns, and modules. Understanding and using Simple Schema is critical for building AI-powered workflows, because it's simpler JSON makes it much easier for AI to read, understand, and build. Beefree SDK's full JSON is complex and feature-rich, making it difficult to train AI on.&#x20;
+
+#### **Template Structure**
+
+The following code snippet shows the template structure for simple JSON.&#x20;
+
 ```json
 {
   "template": {
@@ -61,20 +88,28 @@ The Simple Schema is a simplified JSON format that makes it easy to generate ema
 }
 ```
 
-#### Supported Module Types
-- `title` - Email titles and headings
-- `paragraph` - Text content
-- `button` - Call-to-action buttons
-- `image` - Images and graphics
-- `divider` - Visual separators
-- `html` - Custom HTML content
-- `list` - Bulleted or numbered lists
-- `menu` - Navigation menus
-- `icons` - Social media icons
+#### **Supported Module Types**
+
+Simple Schema supports the following module types:
+
+* `title` - Email titles and headings
+* `paragraph` - Text content
+* `button` - Call-to-action buttons
+* `image` - Images and graphics
+* `divider` - Visual separators
+* `html` - Custom HTML content
+* `list` - Bulleted or numbered lists
+* `menu` - Menus
+* `icons` - Social media and other icons
 
 ### 2. Anthropic API Integration
 
-#### API Call Structure
+This section discusses how to structure and make an API call to Anthropic.
+
+#### **API Call Structure**
+
+The following code snippet shows an example API call to Anthropic.
+
 ```javascript
 const response = await fetch('https://api.anthropic.com/v1/messages', {
   method: 'POST',
@@ -94,7 +129,10 @@ const response = await fetch('https://api.anthropic.com/v1/messages', {
 });
 ```
 
-#### Sample Request
+#### **Sample Request**
+
+The following code snippet shows an example prompt. It includes pre-defined instructions, and the end user's input on the frontend to guide the creation of the email template.&#x20;
+
 ```javascript
 const prompt = `Use this email marketer's description of their dream email to design a stunning email that meets all of the requirements they outlined in their description. Here is the description: "${userDescription}". The email you deliver should meet industry best practices in email marketing and adhere to trending design tips from the best email designers in the industry. The final output should be in Beefree SDK's simple template schema format. 
 
@@ -150,8 +188,11 @@ For each module type, include appropriate content. For example:
 Do NOT invent any properties or structures that do not exist in this simple unified schema, strictly use only what is available here. The final email should be delivered in the response as a simple schema template. Make sure the JSON is valid and complete.`;
 ```
 
-#### Sample Response
-```json
+#### **Sample Response**
+
+The following code snippet shows an example response from Anthropic.
+
+````json
 {
   "id": "msg_01MVjrNK8LRDxEEFdWuHRdED",
   "type": "message",
@@ -169,11 +210,14 @@ Do NOT invent any properties or structures that do not exist in this simple unif
     "output_tokens": 1809
   }
 }
-```
+````
 
 ### 3. Frontend Integration
 
-#### Capturing User Input
+This section discusses the Frontend integration and how to capture an end user's email description prompt, and pass it to the Anthropic API call for context on what type of email template it should build.
+
+#### **Capturing User Input**
+
 ```javascript
 function sendMessage() {
   if (isProcessing) return;
@@ -189,7 +233,8 @@ function sendMessage() {
 }
 ```
 
-#### Sending to Anthropic API
+#### **Sending to Anthropic API**
+
 ```javascript
 async function processEmailRequest(userDescription) {
   isProcessing = true;
@@ -234,8 +279,11 @@ async function processEmailRequest(userDescription) {
 
 ### 4. Response Parsing
 
-#### Extracting JSON from Response
-```javascript
+This section includes two important topics. The first is how to parse the response from Anthropic to only get the simple JSON and pass it to the `/simple-to-full-json` endpoint. The second is how to configure a second API call in the event the first one fails. Beefree SDK provides comprehensive feedback in the error message for a failed `/simple-to-full-json` API call. By applying this comprehensive feedback in a second API, the AI model being used can tyically return a valid simple JSON ready for conversion to full JSON.
+
+#### **Extracting JSON from Response**
+
+````javascript
 // Extract the text content from the response
 let emailJsonText = '';
 if (data.content && data.content.length > 0) {
@@ -279,9 +327,10 @@ try {
   console.error('Raw response text:', emailJsonText);
   throw new Error(`Invalid JSON format in response: ${parseError.message}`);
 }
-```
+````
 
-#### Error Correction Loop
+#### **Error Correction Loop**
+
 ```javascript
 // If Beefree CSAPI returns validation errors, send back to Anthropic for correction
 if (!beefreeResponse.ok) {
@@ -331,7 +380,10 @@ const correctionResponse = await fetch('/api/anthropic', {
 
 ### 5. Beefree SDK Integration
 
-#### Converting Simple to Full JSON
+This section discusses the Beefree SDK integration. Beefree SDK provides the editing environment to load the full JSON into once it is created. Once it is loaded within the editor, the end user can begin customizing their AI-generated email design.
+
+#### **Converting Simple to Full JSON**
+
 ```javascript
 // Convert simple JSON to full JSON using Beefree CSAPI
 const beefreeResponse = await fetch('/api/beefree/simple-to-full', {
@@ -356,7 +408,8 @@ console.log('Full JSON from Beefree:', fullJson);
 localStorage.setItem('fullEmailJson', JSON.stringify(fullJson));
 ```
 
-#### Loading in Beefree SDK Builder
+#### **Loading in Beefree SDK Builder**
+
 ```javascript
 // In builder.html
 let selectedTemplate = null;
@@ -445,7 +498,10 @@ function initializeBeefree(authResponse) {
 
 ## Complete Implementation
 
-### Proxy Server (proxy-server.js)
+This section includes the code for both APIs together (Anthropic API call and `/simple-to-full-json` API call), and the dependencies they require.&#x20;
+
+#### Proxy Server (proxy-server.js)
+
 ```javascript
 const express = require('express');
 const cors = require('cors');
@@ -548,18 +604,21 @@ app.listen(PORT, () => {
 
 ## Customization Tips
 
-1. **Prompt Engineering**: Modify the prompt to generate different types of emails or include specific branding requirements
-2. **Module Types**: Add custom module types or modify existing ones based on your needs
-3. **Error Handling**: Implement more sophisticated error correction logic
-4. **Template Validation**: Add additional validation before sending to Beefree API
-5. **Caching**: Implement caching for frequently requested email types
-6. **User Experience**: Add progress indicators and better error messages
+This section list a few customization tips you can apply to the code in your own environment.&#x20;
+
+* **Prompt Engineering**: Modify the prompt to generate different types of emails or include specific branding requirements
+* **Module Types**: Add custom module types or modify existing ones based on your needs
+* **Error Handling**: Implement more sophisticated error correction logic
+* **Template Validation**: Add additional validation before sending to Beefree API
+* **User Experience**: Add progress indicators and better error messages
 
 ## Troubleshooting
 
-- **JSON Parsing Errors**: Check the raw response from Anthropic and adjust parsing logic
-- **Beefree Validation Errors**: Review the error details and update the correction prompt
-- **API Rate Limits**: Implement rate limiting and retry logic
-- **Template Loading Issues**: Verify localStorage permissions and data format
+If you encounter any errors, try troubleshooting the following:
 
-This recipe provides a complete foundation for building AI-powered email creation systems with Beefree SDK and Anthropic's Claude API. 
+* **JSON Parsing Errors**: Check the raw response from Anthropic and adjust parsing logic
+* **Beefree Validation Errors**: Review the error details and update the correction prompt
+* **API Rate Limits**: Implement rate limiting and retry logic
+* **Template Loading Issues**: Verify localStorage permissions and data format
+
+This recipe provides a complete foundation for building AI-powered email creation systems with Beefree SDK and Anthropic's Messages API and Claude Sonnet 4 model.


### PR DESCRIPTION
# Overview
Extended the demo examples to include a new example. This is an example of how to apply edits to an existing design within the Beefree SDK email editor. This demo is available in the new `partial-design-edits-concept` folder.

## How it works
This demo is different than others, because it also uses the `/full-to-simple-json endpoint` within the [Beefree SDK Content Services API](https://docs.beefree.io/beefree-sdk/apis/content-services-api/convert#full-to-simple-json). The integration of this endpoint provides a full circle feedback loop for editing existing designs with AI. The AI provider in this example is Anthropic, but it can be customized for any provider.

It works by:

1. Converting the existing full JSON to simple JSON
2. Passing the simple JSON and the end user's requested edits (in text format) to the [Anthropic Messages API](https://docs.anthropic.com/en/api/messages) 
3. Anthropic is instructed to only apply edits to the simple JSON using the end user's description and valid simple JSON format based on the `simple_unified.schema.json` file
4. Anthropic returns an edited simple JSON
5. That simple JSON is converted to full JSON using the `/simple-to-full-json` endpoint with the [Content Services API](https://docs.beefree.io/beefree-sdk/apis/content-services-api/convert#simple-to-full-json)
7. The full JSON is loaded within the builder
8. The end user sees their edits applied to the design

Notes and considerations:
- The larger a template is, the more time Anthropic needs to apply the edits and return the simple JSON
- Not all modules within Beefree SDK are compatible with simple schema yet
- Reference [compatible modules in the documentation](https://docs.beefree.io/beefree-sdk/apis/content-services-api/convert#full-to-simple-limitations) before converting